### PR TITLE
Add support for @since and @available tag in comment

### DIFF
--- a/Application/GBApplicationStringsProvider.m
+++ b/Application/GBApplicationStringsProvider.m
@@ -74,6 +74,7 @@
 		[result setObject:@"Properties" forKey:@"propertiesTitle"];
 		[result setObject:@"Parameters" forKey:@"parametersTitle"];
 		[result setObject:@"Return Value" forKey:@"resultTitle"];
+		[result setObject:@"Availability" forKey:@"availability"];
 		[result setObject:@"Discussion" forKey:@"discussionTitle"];
 		[result setObject:@"Exceptions" forKey:@"exceptionsTitle"];
 		[result setObject:@"See Also" forKey:@"seeAlsoTitle"];

--- a/Application/GBCommentComponentsProvider.h
+++ b/Application/GBCommentComponentsProvider.h
@@ -70,6 +70,9 @@
 /** Returns the regex used for matching cross reference directive with capture 1 containing directive, capture 3 link. */
 @property (readonly) NSString *relatedSymbolRegex;
 
+/** Returns the regex used for matching cross reference directive with capture 1 containing directive, capture 2 description text. */
+@property (readonly) NSString *availabilityRegex;
+
 ///---------------------------------------------------------------------------------------
 /// @name Markdown specific definitions
 ///---------------------------------------------------------------------------------------

--- a/Application/GBCommentComponentsProvider.m
+++ b/Application/GBCommentComponentsProvider.m
@@ -74,6 +74,10 @@
 	GBRETURN_ON_DEMAND([self descriptionCaptureRegexForKeyword:@"(?:sa|see)"]);
 }
 
+- (NSString *)availabilityRegex {
+	GBRETURN_ON_DEMAND([self descriptionCaptureRegexForKeyword:@"(?:available|since)"]);
+}
+
 #pragma mark Markdown detection
 
 - (NSString *)markdownInlineLinkRegex {

--- a/Generating/GBDocSetOutputGenerator.m
+++ b/Generating/GBDocSetOutputGenerator.m
@@ -293,6 +293,10 @@
 				NSDictionary *resultData = [NSDictionary dictionaryWithObject:method.comment.methodResult forKey:@"abstract"];
 				[data setObject:resultData forKey:@"returnValue"];
 			}
+			if (method.comment.hasAvailability) {
+				NSDictionary *resultData = [NSDictionary dictionaryWithObject:method.comment.availability forKey:@"abstract"];
+				[data setObject:resultData forKey:@"availability"];
+			}
 		}
 	}
 }

--- a/Model/GBComment.h
+++ b/Model/GBComment.h
@@ -21,6 +21,7 @@
  - `methodParameters`: The list of all method parameters. Only used for methods.
  - `methodResult`: Description of method result. Only used for methods.
  - `methodExceptions`: The list of all possible exceptions. Only used for methods.
+ - `availability`: A text representing the version at which this method / property is available. Can also be applied to other entities
  - `relatedItems`: The list of all related items. Used for cross referencing other entities.
  
  All lists must be provided in the desired order of output - i.e. output formatters don't apply any sorting, they simply emit the values in the given order.
@@ -105,6 +106,11 @@
  */
 @property (retain) GBCommentComponentsList *methodResult;
 
+/** Entity availability description.
+
+ */
+@property (retain) GBCommentComponentsList *availability;
+
 ///---------------------------------------------------------------------------------------
 /// @name Output generator helpers
 ///---------------------------------------------------------------------------------------
@@ -170,6 +176,12 @@
  @see hasMethodExceptions
  */
 @property (readonly) BOOL hasMethodResult;
+
+/** Specifies whether the `availability` contains at least one object or not.
+ 
+ @see availability
+ */
+@property (readonly) BOOL hasAvailability;
 
 /** Specifies whether the `relatedItems` contains at least one object or not.
  */

--- a/Model/GBComment.m
+++ b/Model/GBComment.m
@@ -32,6 +32,7 @@
 		self.methodParameters = [NSMutableArray array];
 		self.methodExceptions = [NSMutableArray array];
 		self.methodResult = [GBCommentComponentsList componentsList];
+		self.availability = [GBCommentComponentsList componentsList];
 	}
 	return self;
 }
@@ -72,6 +73,10 @@
 	return [self.relatedItems.components count] > 0;
 }
 
+- (BOOL)hasAvailability {
+	return [self.availability.components count] > 0;
+}
+
 - (BOOL)isCopied {
 	return (self.originalContext != nil);
 }
@@ -88,5 +93,6 @@
 @synthesize methodParameters;
 @synthesize methodExceptions;
 @synthesize methodResult;
+@synthesize availability;
 
 @end

--- a/Templates/html/object-template.html
+++ b/Templates/html/object-template.html
@@ -238,6 +238,13 @@ Section Method
 	</div>
 	{{/hasMethodResult}}
 	
+	{{#hasAvailability}}
+	<div class="method-subsection availability">
+		<h4 class="method-subtitle parameter-title">{{strings/objectMethods/availability}}</h4>
+		{{#availability}}{{>GBCommentComponentsList}}{{/availability}}
+	</div>
+	{{/hasAvailability}}
+	
 	{{#hasLongDescription}}
 	<div class="method-subsection discussion-section">
 		<h4 class="method-subtitle">{{strings/objectMethods/discussionTitle}}</h4>

--- a/Testing/GBCommentTesting.m
+++ b/Testing/GBCommentTesting.m
@@ -25,6 +25,7 @@
 	assertThat(comment.methodParameters, isNot(nil));
 	assertThat(comment.methodExceptions, isNot(nil));
 	assertThat(comment.methodResult, isNot(nil));
+	assertThat(comment.availability, isNot(nil));
 }
 
 #pragma mark Comment components testing


### PR DESCRIPTION
Using @since or @available comment in a method description will generate a new section in the method doc. called "Availability" as in Apple doc. The content of that section will be the text following the @since or @available tag.
