### PR TITLE
Added support for termination macros for method declaration and properties declaration 

### DIFF
--- a/Parsing/GBTokenizer.h
+++ b/Parsing/GBTokenizer.h
@@ -88,8 +88,18 @@
  @param offset The offset from the current position.
  @return Returns the token at the given offset or EOF token if offset point after EOF.
  @see consume:
+ @see lookaheadTo:usingBlock:
  */
 - (PKToken *)lookahead:(NSUInteger)offset;
+
+/** Enumerates but does not consume all tokens starting at current token up until the given end token is detected.
+ 
+ For each token, the given block is called which gives client a chance to inspect and handle tokens. End token is not reported. Note that this method automatically skips any comment tokens and only enumerates actual language tokens.
+ 
+ @param end Ending token.
+ @see lookahead:
+ */
+- (void)lookaheadTo:(NSString *)end usingBlock:(void (^)(PKToken *token, BOOL *stop))block;
 
 /** Consumes the given ammoun of tokens, starting at the current position.
  

--- a/Parsing/GBTokenizer.m
+++ b/Parsing/GBTokenizer.m
@@ -87,6 +87,23 @@
 	return [self.tokens objectAtIndex:self.tokenIndex + delta - 1];
 }
 
+- (void)lookaheadTo:(NSString *)end usingBlock:(void (^)(PKToken *token, BOOL *stop))block {
+    NSUInteger tokenCount = [self.tokens count];
+	BOOL quit = NO;
+    for (NSUInteger index = self.tokenIndex; index < tokenCount; ++index) {
+        PKToken *token = [self.tokens objectAtIndex:index];
+		if ([token isComment]) {
+			index++;
+			continue;
+		}
+		if ([token matches:end]) {
+            break;
+		}
+        block(token, &quit);
+		if (quit) break;
+	}
+}
+
 - (PKToken *)currentToken {
 	if ([self eof]) return [PKToken EOFToken];
 	return [self.tokens objectAtIndex:self.tokenIndex];


### PR DESCRIPTION
Hi, this pull request is the good one :-)

appledoc was not able to properly parse custom termination macros, such as the following declaration:

```
- (id)foo MACRO;
- (id)bar:(id)baz MACRO;
@property int p1 MACRO;
@property void(^p2)(void) MACRO;
```

This pull request adds the following method to the `GBTokenizer` class:

```
- (void)lookaheadTo:(NSString *)end usingBlock:(void (^)(PKToken *token, BOOL *stop))block;
```

This method allows `[GBObjectiveCParser matchMethodDataForProvider:from:to:required:]` to look ahead an argument name for further colons `:`. If there is none, remaining tokens are handled as termination macros.

Also, `[GBMethodData propertyDataWithAttributes:components:]` has been enhanced in order to set the property name apart from the return type, without help from `[GBObjectiveCParser matchPropertyDefinitionForProvider:required:]` in the specific case of block properties.
