### PR TITLE
Follow up to tomaz/appledoc#144

### DIFF
--- a/Model/GBMethodArgument.h
+++ b/Model/GBMethodArgument.h
@@ -23,39 +23,40 @@
 
 /** Returns autoreleased method argument with the given parameters.
  
- Internally this sends allocated instance `initWithName:types:var:terminationMacros:` message, so check it's documentation for details.
+ Internally this sends allocated instance `initWithName:types:var:variableArg:terminationMacros:` message, so check it's documentation for details.
  
  @param name The name of the method argument, part of method selector.
  @param types Array of argument types in the form of `NSString` instances or `nil` if not used.
  @param var Array of arguments in the form of `GBMethodArgument` instances or `nil` if not used.
- @param macros Array of variable arg termination macros or `nil` if not variable arg.
+ @param variableArg whether the last named parameter accepts indefinite number of arguments
+ @param macros Array of termination macros
  @return Returns initialized object or `nil` if initialization fails.
  @exception NSException Thrown if either of the given parameters is invalid.
- @see initWithName:types:var:terminationMacros:
+ @see initWithName:types:var:variableArg:terminationMacros:
  */
-+ (id)methodArgumentWithName:(NSString *)name types:(NSArray *)types var:(NSString *)var terminationMacros:(NSArray *)macros;
++ (id)methodArgumentWithName:(NSString *)name types:(NSArray *)types var:(NSString *)var variableArg:(BOOL)variableArg terminationMacros:(NSArray *)macros;
 
 /** Returns autoreleased method argument with the given parameters.
  
- Internally this sends allocated instance `initWithName:types:var:terminationMacros:` message, so check it's documentation for details.
+ Internally this sends allocated instance `initWithName:types:var:variableArg:terminationMacros:` message, so check it's documentation for details.
  
  @param name The name of the method argument, part of method selector.
  @param types Array of argument types in the form of `NSString` instances or `nil` if not used.
  @param var Array of arguments in the form of `GBMethodArgument` instances or `nil` if not used.
  @return Returns initialized object or `nil` if initialization fails.
  @exception NSException Thrown if either of the given parameters is invalid.
- @see initWithName:types:var:terminationMacros:
+ @see initWithName:types:var:variableArg:terminationMacros:
  */
 + (id)methodArgumentWithName:(NSString *)name types:(NSArray *)types var:(NSString *)var;
 
 /** Returns autoreleased type-less method argument.
  
- Internally this sends allocated instance `initWithName:types:var:terminationMacros:` message, so check it's documentation for details.
+ Internally this sends allocated instance `initWithName:types:var:variableArg:terminationMacros:` message, so check it's documentation for details.
  
  @param name The name of the method argument, part of method selector.
  @return Returns initialized object or `nil` if initialization fails.
  @exception NSException Thrown if the argument is `nil` or empty string.
- @see initWithName:types:var:terminationMacros:
+ @see initWithName:types:var:variableArg:terminationMacros:
  */
 + (id)methodArgumentWithName:(NSString *)name;
 
@@ -68,11 +69,12 @@
  @param argument The name of the method argument, part of method selector.
  @param types Array of argument types in the form of `NSString` instances or `nil` if not used.
  @param var Array of arguments in the form of `GBMethodArgument` instances or `nil` if not used.
- @param macros Array of variable arg termination macros or `nil` if not variable arg.
+ @param variableArg whether the last named parameter accepts indefinite number of arguments
+ @param macros Array of termination macros
  @return Returns initialized object or `nil` if initialization fails.
  @exception NSException Thrown if either of the given parameters is invalid.
  */
-- (id)initWithName:(NSString *)argument types:(NSArray *)types var:(NSString *)var terminationMacros:(NSArray *)macros;
+- (id)initWithName:(NSString *)argument types:(NSArray *)types var:(NSString *)var variableArg:(BOOL)variableArg terminationMacros:(NSArray *)macros;
 
 ///---------------------------------------------------------------------------------------
 /// @name Argument data

--- a/Model/GBMethodArgument.m
+++ b/Model/GBMethodArgument.m
@@ -12,19 +12,19 @@
 
 #pragma mark Initialization & disposal
 
-+ (id)methodArgumentWithName:(NSString *)name types:(NSArray *)types var:(NSString *)var terminationMacros:(NSArray *)macros {
-	return [[[self alloc] initWithName:name types:types var:var terminationMacros:macros] autorelease];
++ (id)methodArgumentWithName:(NSString *)name types:(NSArray *)types var:(NSString *)var variableArg:(BOOL)variableArg terminationMacros:(NSArray *)macros {
+	return [[[self alloc] initWithName:name types:types var:var variableArg:variableArg terminationMacros:macros] autorelease];
 }
 
 + (id)methodArgumentWithName:(NSString *)name types:(NSArray *)types var:(NSString *)var {
-	return [self methodArgumentWithName:name types:types var:var terminationMacros:nil];
+	return [self methodArgumentWithName:name types:types var:var variableArg:NO terminationMacros:nil];
 }
 
 + (id)methodArgumentWithName:(NSString *)name {
-	return [self methodArgumentWithName:name types:[NSArray array] var:nil terminationMacros:nil];
+	return [self methodArgumentWithName:name types:[NSArray array] var:nil variableArg:NO terminationMacros:nil];
 }
 
-- (id)initWithName:(NSString *)name types:(NSArray *)types var:(NSString *)var terminationMacros:(NSArray *)macros {
+- (id)initWithName:(NSString *)name types:(NSArray *)types var:(NSString *)var variableArg:(BOOL)variableArg terminationMacros:(NSArray *)macros {
 	NSParameterAssert(name != nil);
 	NSParameterAssert(([types count] == 0 && var == nil) || ([types count] > 0 && var != nil));
 	self = [super init];
@@ -33,7 +33,7 @@
 		_argumentTypes = [types retain];
 		_argumentVar = [var copy];
 		_terminationMacros = macros ? [macros retain] : [[NSArray alloc] init];
-		self.isVariableArg = (macros != nil);
+		self.isVariableArg = variableArg;
 	}
 	return self;
 }

--- a/Parsing/GBObjectiveCParser.m
+++ b/Parsing/GBObjectiveCParser.m
@@ -499,6 +499,7 @@
 			__block NSString *argumentVar = nil;
 			__block NSMutableArray *argumentTypes = [NSMutableArray array];
 			__block NSMutableArray *terminationMacros = [NSMutableArray array];
+            __block BOOL variableArg = NO;
 			if ([[self.tokenizer currentToken] matches:@":"]) {
 				[self.tokenizer consume:1];
 				
@@ -515,6 +516,7 @@
 				
 				// If we have variable args block following, consume the rest of the tokens to get optional termination macros.
 				if ([[self.tokenizer lookahead:0] matches:@","] && [[self.tokenizer lookahead:1] matches:@"..."]) {
+                    variableArg = YES;
 					[self.tokenizer consume:2];
 					[self.tokenizer consumeTo:end usingBlock:^(PKToken *token, BOOL *consume, BOOL *stop) {
 						[terminationMacros addObject:[token stringValue]];
@@ -548,7 +550,7 @@
                 *stop = YES; // Ignore the rest of parameters
             }
             
-            GBMethodArgument *argument = [GBMethodArgument methodArgumentWithName:argumentName types:argumentTypes var:argumentVar terminationMacros:terminationMacros];
+            GBMethodArgument *argument = [GBMethodArgument methodArgumentWithName:argumentName types:argumentTypes var:argumentVar variableArg:variableArg terminationMacros:terminationMacros];
             [methodArgs addObject:argument];
             *consume = NO;
 		}];

--- a/Testing/GBMethodDataTesting.m
+++ b/Testing/GBMethodDataTesting.m
@@ -480,7 +480,7 @@
 	NSArray *results = [NSArray arrayWithObjects:@"void", nil];
 	NSArray *types = [NSArray arrayWithObjects:@"id", nil];
 	NSArray *macros = [NSArray array];
-	NSArray *arguments = [NSArray arrayWithObjects:[GBMethodArgument methodArgumentWithName:@"method" types:types var:@"format" terminationMacros:macros], nil];
+	NSArray *arguments = [NSArray arrayWithObjects:[GBMethodArgument methodArgumentWithName:@"method" types:types var:@"format" variableArg:NO terminationMacros:macros], nil];
 	GBMethodData *method = [GBMethodData methodDataWithType:GBMethodTypeInstance result:results arguments:arguments];
 	// execute
 	NSArray *result = [method formattedComponents];


### PR DESCRIPTION
Without this patch, all methods having termination macros are outputed with varArgs (...).

Content of this commit: [GBMethodArgument isVariableArg] is no longer inferred from termination macros. It is now directly set by GBObjectiveCParser.
