### PR TITLE
Re: issue #148; parsing of @property

### DIFF
--- a/Model/GBMethodData.m
+++ b/Model/GBMethodData.m
@@ -71,6 +71,9 @@
 		} else if ([component isEqualToString:@"*"]) {
 			[results addObject:component];
 			nextComponentIsPropertyName = YES;
+		} else if ([component isEqualToString:@"id"]) {
+			[results addObject:component];
+			nextComponentIsPropertyName = YES;
         } else if ([component isMatchedByRegex:@"^[_a-zA-Z][_a-zA-Z0-9]$"]) {
 			if (results.count == 0 || inProtocolsList) {
                 [results addObject:component];

--- a/Testing/GBObjectiveCParser-MethodsParsingTesting.m
+++ b/Testing/GBObjectiveCParser-MethodsParsingTesting.m
@@ -278,6 +278,19 @@
 	[self assertMethod:[methods objectAtIndex:0] matchesPropertyComponents:@"retain", @"nonatomic", @"IBOutlet", @"NSString", @"*", @"name", nil];
 }
 
+- (void)testParseObjectsFromString_shouldRegisterComplexPropertyDefinition2 {
+	// setup
+	GBObjectiveCParser *parser = [GBObjectiveCParser parserWithSettingsProvider:[GBTestObjectsRegistry mockSettingsProvider]];
+	GBStore *store = [[GBStore alloc] init];
+	// execute
+	[parser parseObjectsFromString:@"@interface MyClass @property (weak) IBOutlet id delegate; @end" sourceFile:@"filename.h" toStore:store];
+	// verify
+	GBClassData *class = [[store classes] anyObject];
+	NSArray *methods = [[class methods] methods];
+	assertThatInteger([methods count], equalToInteger(1));
+	[self assertMethod:[methods objectAtIndex:0] matchesPropertyComponents:@"weak", @"IBOutlet", @"id", @"delegate", nil];
+}
+
 - (void)testParseObjectsFromString_shouldRegisterBlockPropertyDefinition {
 	// setup
 	GBObjectiveCParser *parser = [GBObjectiveCParser parserWithSettingsProvider:[GBTestObjectsRegistry mockSettingsProvider]];


### PR DESCRIPTION
property with type id would end up getting propertyName = @"id" instead of actual property name. Also a test case.

See issue #148
