### PR TITLE
Fix handling of +[NSException raise:format:]

### DIFF
--- a/Common/NSException+GBException.h
+++ b/Common/NSException+GBException.h
@@ -35,6 +35,6 @@
  @param ... A comma separated list of arguments to substitute into the format.
  @exception NSException Always thrown ;)
  */
-+ (void)raise:(NSError *)error format:(NSString *)format, ...;
++ (void)raise:(NSString *)name format:(NSString *)format, ...;
 
 @end

--- a/Common/NSException+GBException.m
+++ b/Common/NSException+GBException.m
@@ -10,7 +10,7 @@
 
 @interface NSException (GBExceptionPrivate)
 
-+ (NSString *)reasonWithError:(NSError *)error message:(NSString *)message;
++ (NSString *)reasonWithError:(NSString *)name message:(NSString *)message;
 
 @end
 
@@ -25,7 +25,7 @@
 	va_end(args);
 }
 
-+ (void)raise:(NSError *)error format:(NSString *)format, ... {
++ (void)raise:(NSString *)name format:(NSString *)format, ... {
 	NSString *message = nil;
 	if (format) {
 		va_list args;
@@ -34,20 +34,14 @@
 		va_end(args);
 	}
 	
-	NSString *reason = [self reasonWithError:error message:message];
+	NSString *reason = [self reasonWithError:name message:message];
 	[self raise:reason];
 }
 
-+ (NSString *)reasonWithError:(NSError *)error message:(NSString *)message {
-	NSInteger code = [error code];
-	NSString *domain = [error domain];
-	NSString *description = [error localizedDescription];
-	NSString *reason = [error localizedFailureReason];
-	
++ (NSString *)reasonWithError:(NSString *)name message:(NSString *)message {
 	NSMutableString *result = [NSMutableString string];
 	if (message) [result appendFormat:@"%@\n", message];
-	[result appendFormat:@"Error: %@, code %i: %@\n", domain, code, description];
-	if (reason) [result appendFormat:@"Reason: %@", reason];
+	[result appendFormat:@"Error: %@\n", name];
 	return result;
 }
 


### PR DESCRIPTION
This bug caused:
NSInvalidArgumentException: -[__NSCFConstantString code]: unrecognized selector sent to instance 0x7fff7736ce00

The solution will still show the NSError details if somebody decides to
raise an NSError instead of an NSString, going in against the documented
usage of raise (see Apple docs on NSException):
- (void)raise:(NSString *)name format:(NSString *)format, ...
