### PR TITLE
Fixed CSS a/code conflixt

### DIFF
--- a/Templates/html/css/styles.css
+++ b/Templates/html/css/styles.css
@@ -28,12 +28,12 @@ li {
 	margin-bottom: 10px;
 }
 
-a {
+a, a code {
 	text-decoration: none;
 	color: #36C;
 }
 
-a:hover {
+a:hover, a:hover code {
 	text-decoration: underline;
 	color: #36C;
 }


### PR DESCRIPTION
Fixed CSS so that 'a' tag overwrites 'code' to fix cases when code decorators are placed around code references.
