### PR TITLE
typo

### DIFF
--- a/Parsing/GBTokenizer.m
+++ b/Parsing/GBTokenizer.m
@@ -312,7 +312,7 @@
 }
 
 - (NSArray *)linesByReorderingHeaderDocDirectives:(NSArray *)lines {
-#if MAC_OS_X_VERSION_MIN_REQUIRED > __MAC_10_6
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
 	if (!self.settings.preprocessHeaderDoc) return lines;
 
 	// Make sure that @param and @return is placed at the end (after abstract etc.)


### PR DESCRIPTION
here the correct way.

I just read that it's a NO-NO to do 'git --amend' so I did not do it.

So here another commit. (Is there a better way ?)

How can we test this option 'HeaderDoc' on 10.7 ? Could you do it on a branch before the merge ?

Running 'appledoc --help',  I don't see the '--preprocess-headerdoc' option... just missing in the help ?
I see only one reference to this string in GBApplicationTesting.m

(I'm reading your intention in the comment of commit: 2e063c0e1ecb2dbf260d0346879939f90a39fe32)
