### PR TITLE
fix crash when making cross reference from static markdown document

### DIFF
--- a/Processing/GBCommentsProcessor.m
+++ b/Processing/GBCommentsProcessor.m
@@ -716,7 +716,7 @@ typedef NSUInteger GBProcessingFlag;
 		else if ([object isKindOfClass:[GBProtocolData class]])
 			if ([data->description isEqualToString:[object nameOfProtocol]]) return YES;
 	} else {
-		if ([data->description isEqualToString:[object methodSelector]]) return YES;
+		if (![object isKindOfClass:[GBDocumentData class]] && [data->description isEqualToString:[object methodSelector]]) return YES;
 	}
 	return NO;
 }


### PR DESCRIPTION
I have a reproducable crash being triggered by a cross reference from a static markdown document to a documented source class (I can provide an archive which demonstrates the problem if needed).  The code which prevents cross references to the current entity does not work correctly in the context of a GBDocumentData object.

It looks like the isCrossReference:matchingObject: code is implicitly assuming a GBMethodData in this case, so checking for GBDocumentData addresses the issue.  However, it might be preferable to use another mechanism like respondsToSelector: if there are other kinds of objects that can fall through to this case -- I don't know enough about the appledoc design here to say which is best, but I can make that change if you'd prefer.
