### PR TITLE
Show method declaration even without doc comment

### DIFF
--- a/Templates/html/object-template.html
+++ b/Templates/html/object-template.html
@@ -230,9 +230,11 @@ Section Method
 		{{#shortDescription}}{{>GBCommentComponent}}{{/shortDescription}}
 	</div>		
 	{{/hasShortDescription}}
-	
+    {{/comment}}
+
 	<div class="method-subsection method-declaration"><code>{{>MethodDeclaration}}</code></div>
-	
+
+    {{#comment}}
 	{{#hasMethodParameters}}
 	<div class="method-subsection arguments-section parameters">
 		<h4 class="method-subtitle parameter-title">{{strings/objectMethods/parametersTitle}}</h4>


### PR DESCRIPTION
Hi.
We are using appledoc in [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager. Next version will automatically generate appledoc documentation for every library installed with it.
We've found a small issue. If there is no doc comments, then doc will not contain any type info for properties and methods ([discussion](https://groups.google.com/forum/?fromgroups#!topic/cocoapods/dhYg8UNnYqo), [screenshot](http://twitpic.com/98svq5)).
This commit fixes this issue by displaying method declaration even without the comments ([screenshot](http://habrastorage.org/storage2/c0f/c23/74c/c0fc2374c7f774847eeefd62c4e6c389.png)).
