### PR TITLE
Allow the selection of a template path at compile time

### DIFF
--- a/Application/GBAppledocApplication.m
+++ b/Application/GBAppledocApplication.m
@@ -496,6 +496,16 @@ static NSString *kGBArgHelp = @"help";
 			self.templatesFound = YES;
 			return;
 		}
+
+        #ifdef COMPILE_TIME_DEFAULT_TEMPLATE_PATH
+		path = COMPILE_TIME_DEFAULT_TEMPLATE_PATH;
+		if ([self validateTemplatesPath:path error:nil]) {
+			[self overrideSettingsWithGlobalSettingsFromPath:path];
+			self.settings.templatesPath = path;
+			self.templatesFound = YES;
+			return;
+		}
+        #endif
 	}
 }
 


### PR DESCRIPTION
This path takes the least precedence, and allows packaging systems
like Homebrew to place the templates from the current version in
a path which this binary will look for as a last resort.

That makes the default case of, "please give me the latest version
of the templates," work seamlessly, while also allowing anyone to
override it using the existing instructions in the documentation.

--Tim
