### PR TITLE
Quoted PROJECT_DIR in build-step to handle paths that contain spaces or shell-characters

### DIFF
--- a/appledoc.xcodeproj/project.pbxproj
+++ b/appledoc.xcodeproj/project.pbxproj
@@ -1263,7 +1263,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#!/bin/bash\n\ncd Templates\nzip -r default_templates.zip .\nmv default_templates.zip $PROJECT_DIR\ncd ..";
+			shellScript = "#!/bin/bash\n\ncd Templates\nzip -r default_templates.zip .\nmv default_templates.zip \"$PROJECT_DIR\"\ncd ..";
 		};
 		B4D1FFF515FF637A009736E2 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
The PROJECT_DIR environment variable was used without quotes in a build-step. This would cause problems if the path where the project was stored contained spaces or shell-characters.
The solution is to always enclose variables with quotes "" if they are being used as path/file arguments.
