### PR TITLE
Allow publication task even if the Xcode reload AppleScript fails

### DIFF
--- a/Generating/GBDocSetInstallGenerator.m
+++ b/Generating/GBDocSetInstallGenerator.m
@@ -61,8 +61,7 @@
 	if (![script executeAndReturnError:&errorDict])
 	{
 		NSString *message = [errorDict objectForKey:NSAppleScriptErrorMessage];
-		if (error) *error = [NSError errorWithCode:GBErrorDocSetXcodeReloadFailed description:@"Documentation set was installed, but couldn't reload documentation within Xcode." reason:message];
-		return NO;
+		GBLogWarn(@"Warning: Documentation set was installed, but couldn't reload documentation within Xcode. %@", message)
 	}
 	return YES;
 }


### PR DESCRIPTION
The Xcode reload script is not a critical task, and it usually fails on a Continuous Integration service like Jenkins. But when a reload error occurs, the publication task is not executed.

This code change the error level generated from the Xcode documentation reload
failure to a warning level to allow any publication task to be executed.
