### PR TITLE
Add the ability to suppress warnings for undocumented parameters

### DIFF
--- a/Application/GBAppledocApplication.m
+++ b/Application/GBAppledocApplication.m
@@ -61,6 +61,7 @@ static NSString *kGBArgWarnOnMissingOutputPath = @"warn-missing-output-path";
 static NSString *kGBArgWarnOnMissingCompanyIdentifier = @"warn-missing-company-id";
 static NSString *kGBArgWarnOnUndocumentedObject = @"warn-undocumented-object";
 static NSString *kGBArgWarnOnUndocumentedMember = @"warn-undocumented-member";
+static NSString *kGBArgWarnOnUndocumentedParam = @"warn-undocumented-param";
 static NSString *kGBArgWarnOnEmptyDescription = @"warn-empty-description";
 static NSString *kGBArgWarnOnUnknownDirective = @"warn-unknown-directive";
 static NSString *kGBArgWarnOnInvalidCrossReference = @"warn-invalid-crossref";
@@ -301,6 +302,7 @@ static NSString *kGBArgHelp = @"help";
 		{ kGBArgWarnOnMissingCompanyIdentifier,								0,		DDGetoptNoArgument },
 		{ kGBArgWarnOnUndocumentedObject,									0,		DDGetoptNoArgument },
 		{ kGBArgWarnOnUndocumentedMember,									0,		DDGetoptNoArgument },
+		{ kGBArgWarnOnUndocumentedParam,									0,		DDGetoptNoArgument },
 		{ kGBArgWarnOnEmptyDescription,										0,		DDGetoptNoArgument },
 		{ kGBArgWarnOnUnknownDirective,										0,		DDGetoptNoArgument },
 		{ kGBArgWarnOnInvalidCrossReference,								0,		DDGetoptNoArgument },
@@ -925,6 +927,7 @@ static NSString *kGBArgHelp = @"help";
 	ddprintf(@"--%@ = %@\n", kGBArgWarnOnMissingCompanyIdentifier, PRINT_BOOL(self.settings.warnOnMissingCompanyIdentifier));
 	ddprintf(@"--%@ = %@\n", kGBArgWarnOnUndocumentedObject, PRINT_BOOL(self.settings.warnOnUndocumentedObject));
 	ddprintf(@"--%@ = %@\n", kGBArgWarnOnUndocumentedMember, PRINT_BOOL(self.settings.warnOnUndocumentedMember));
+	ddprintf(@"--%@ = %@\n", kGBArgWarnOnUndocumentedParam, PRINT_BOOL(self.settings.warnOnUndocumentedParam));
 	ddprintf(@"--%@ = %@\n", kGBArgWarnOnEmptyDescription, PRINT_BOOL(self.settings.warnOnEmptyDescription));
 	ddprintf(@"--%@ = %@\n", kGBArgWarnOnUnknownDirective, PRINT_BOOL(self.settings.warnOnUnknownDirective));
 	ddprintf(@"--%@ = %@\n", kGBArgWarnOnInvalidCrossReference, PRINT_BOOL(self.settings.warnOnInvalidCrossReference));
@@ -993,6 +996,7 @@ static NSString *kGBArgHelp = @"help";
 	PRINT_USAGE(@"   ", kGBArgWarnOnMissingCompanyIdentifier, @"", @"[b] Warn if company ID is not given");
 	PRINT_USAGE(@"   ", kGBArgWarnOnUndocumentedObject, @"", @"[b] Warn on undocumented object");
 	PRINT_USAGE(@"   ", kGBArgWarnOnUndocumentedMember, @"", @"[b] Warn on undocumented member");
+	PRINT_USAGE(@"   ", kGBArgWarnOnUndocumentedParam, @"", @"[b] Warn on undocumented method parameter");
 	PRINT_USAGE(@"   ", kGBArgWarnOnEmptyDescription, @"", @"[b] Warn on empty description block");
 	PRINT_USAGE(@"   ", kGBArgWarnOnUnknownDirective, @"", @"[b] Warn on unknown directive or format");
 	PRINT_USAGE(@"   ", kGBArgWarnOnInvalidCrossReference, @"", @"[b] Warn on invalid cross reference");

--- a/Application/GBApplicationSettingsProvider.h
+++ b/Application/GBApplicationSettingsProvider.h
@@ -391,6 +391,12 @@ extern id kGBCustomDocumentIndexDescKey;
  */
 @property (assign) BOOL warnOnUndocumentedMember;
 
+/** Indicates whether appledoc will warn if it encounters an undocumented method parameter
+ 
+ @see warnOnUndocumentedMember
+ */
+@property (assign) BOOL warnOnUndocumentedParam;
+
 /** Indicates whether appledoc will warn if it encounters an empty description (@bug, @warning, example section etc.).
  */
 @property (assign) BOOL warnOnEmptyDescription;

--- a/Processing/GBProcessor.m
+++ b/Processing/GBProcessor.m
@@ -196,7 +196,7 @@
 	[names enumerateObjectsUsingBlock:^(NSString *name, NSUInteger idx, BOOL *stop) {
 		GBCommentArgument *parameter = [parameters objectForKey:name];
 		if (!parameter) {
-            if (method.includeInOutput)
+            if (self.settings.warnOnUndocumentedParam && method.includeInOutput)
                 GBLogXWarn(comment.sourceInfo, @"%@: Description for parameter '%@' missing for %@!", comment.sourceInfo, name, method);
 			return;
 		}


### PR DESCRIPTION
I wasn't quite sure what --warn-missing-arg was supposed to do, but from the code it looks like it controls warning when you've documented a parameter that doesn't exist, but let me know if there's a better way to fix this.
