### PR TITLE
Fix for issue #299

### DIFF
--- a/Model/GBMethodData.h
+++ b/Model/GBMethodData.h
@@ -107,6 +107,9 @@ typedef NSUInteger GBMethodType;
  */
 @property (readonly) NSString *methodSelector;
 
+/** Method return type that can be used for shared property/method names. */
+@property (readonly) NSString *methodReturnType;
+
 /** Method selector including prefix.
  
  @see methodSelector
@@ -187,5 +190,13 @@ typedef NSUInteger GBMethodType;
  @return Returns formatted components of the receiver.
  */
 - (NSArray *)formattedComponents;
+
+/** Returns the data type of the property.
+
+ This searches the `methodResultTypes` array and returns the property data type. This only applies to properties, returns `nil` otherwise!
+
+ @see methodResultTypes
+ */
+- (NSString *)propertyType;
 
 @end

--- a/Model/GBMethodData.m
+++ b/Model/GBMethodData.m
@@ -116,6 +116,7 @@
 		_methodPrefix = [[self prefixFromAssignedData] retain];
 		_methodSelectorDelimiter = [[self selectorDelimiterFromAssignedData] retain];
 		_methodSelector = [[self selectorFromAssignedData] retain];
+        _methodReturnType = (NSString *)self.methodResultTypes.firstObject;
 		_prefixedMethodSelector = [[self prefixedSelectorFromAssignedData] retain];
 	}
 	return self;
@@ -279,6 +280,13 @@
 	return result;
 }
 
+- (NSString *)propertyType {
+    if (self.methodType != GBMethodTypeProperty) return nil;
+    NSString *result = (NSString *)self.methodResultTypes.firstObject;
+    if (!result) result = self.methodReturnType;
+    return result;
+}
+
 - (NSString *)attributeValueForKey:(NSString *)key {
 	// Returns the value after equal sign for the given key (i.e. for attributes "getter", "=", "value", this would return "value"). Returns nil if either key isn't found or isn't followed by equal sign and/or a value.
 	__block NSString *result = nil;
@@ -317,10 +325,11 @@
 			[NSException raise:@"Failed merging %@ to %@; method type doesn't match!", source, self];
 		}
 		
-		// We should allow if the getter or setter matches.
+		// We should allow if the getter or setter matches and if the getter name is shared to an instance method.
 		if ([propertyData.propertyGetterSelector isEqualToString:manualData.methodSelector]) return YES;
 		if ([propertyData.propertySetterSelector isEqualToString:manualData.methodSelector]) return YES;
-		[NSException raise:@"Failed merging %@ to %@; getter or setter doesn't match", source, self];
+		if (![propertyData.propertyType isEqualToString:manualData.methodReturnType]) return YES;
+        [NSException raise:@"Failed merging %@ to %@; getter or setter doesn't match", source, self];
 	} else {
 		// If assertion from code below is present, it breaks cases where category declares a property which is also getter for a property from class declaration. See #184 https://github.com/tomaz/appledoc/issues/184 for details. I'm leaving the code commented for the moment to see if it also affects some other user (don't think so, but just in case).
 		//NSParameterAssert([source.methodSelector isEqualToString:self.methodSelector]);
@@ -386,6 +395,7 @@
 @synthesize methodResultTypes = _methodResultTypes;
 @synthesize methodArguments = _methodArguments;
 @synthesize methodSelector = _methodSelector;
+@synthesize methodReturnType = _methodReturnType;
 @synthesize methodSelectorDelimiter = _methodSelectorDelimiter;
 @synthesize methodPrefix = _methodPrefix;
 @synthesize prefixedMethodSelector = _prefixedMethodSelector;


### PR DESCRIPTION
Fixes edge case where you declare a custom getter for a `@property` but share the property name w/ an instance method which results in a raised exception when validating the getter selector.
see #299 
