### PR TITLE
Fixed crash when run without parameters

### DIFF
--- a/Application/GBAppledocApplication.m
+++ b/Application/GBAppledocApplication.m
@@ -512,6 +512,8 @@ static NSString *kGBArgHelp = @"help";
 
 - (void)injectXcodeSettingsFromArguments:(NSArray *)arguments {
     //check if even deal with a project
+    if([arguments count] < 2)
+        return;
     NSString *path = [arguments objectAtIndex:1];
     if(![path.pathExtension isEqualToString:@"xcodeproj"])
         return;


### PR DESCRIPTION
This protects against a crash caused by accessing the first parameter when no parameters are provided. Now displays an error message instead.
