### PR TITLE
Fixed the array access beyond bounds.

### DIFF
--- a/Model/GBMethodData.m
+++ b/Model/GBMethodData.m
@@ -204,7 +204,7 @@
 		if (isLast || isPointer) appendSpace = NO;
 		
 		// We should not add space between components of a protocol (i.e. id<ProtocolName> should be written without any space). Because we've alreay
-		if (!isLast && [[types objectAtIndex:idx+1] isEqualToString:@"<"])
+		if (!isLast && idx+1 < [types count] && [[types objectAtIndex:idx+1] isEqualToString:@"<"])
 			insideProtocol = YES;
 		else if ([type isEqualToString:@">"])
 			insideProtocol = NO;

--- a/Processing/GBCommentsProcessor.m
+++ b/Processing/GBCommentsProcessor.m
@@ -406,7 +406,7 @@ typedef NSUInteger GBProcessingFlag;
 	if ([components count] == 0) return NO;
 	
 	// Get data from captures. Index 1 is directive, index 2 description text.
-	NSString *description = [components objectAtIndex:3];
+	NSString *description = [components count] > 3 ? [components objectAtIndex:3] : @"";
 	NSRange range = [string rangeOfString:description];
 	NSString *prefix = nil;
 	if (range.location < [string length]) {


### PR DESCRIPTION
It has crashed for some projects with following stacktrace.

---

NSRangeException: **\* -[__NSArrayI objectAtIndex:]: index 3 beyond bounds [0 .. 2]
  @ 0   CoreFoundation                      0x00007fff87bf8f56 __exceptionPreprocess + 198
  @ 1   libobjc.A.dylib                     0x00007fff8fac7dee objc_exception_throw + 43
  @ 2   CoreFoundation                      0x00007fff87ba2370 -[__NSArrayI objectAtIndex:] + 208
  @ 3   appledoc                            0x00000001053eff60 _mh_execute_header + 155488
...

---

So, I added the bounds checking.
