### PR TITLE
Fixing Bug with Feed Generating Package URL

### DIFF
--- a/Generating/GBDocSetPublishGenerator.m
+++ b/Generating/GBDocSetPublishGenerator.m
@@ -102,13 +102,15 @@
     }
     
     if(self.settings.docsetFeedFormats & GBPublishedFeedFormatXML)
-    {        
+    {
+        NSString *extension = @"tgz";
+        
         NSMutableArray *args = [NSMutableArray array];
         [args addObject:@"tar"];
         [args addObject:@"--exclude"];
         [args addObject:@".DS_Store"];
         [args addObject:@"-czPf"];
-        [args addObject:[[outputDocSetPath stringByStandardizingPath] stringByAppendingString:@".tgz"]];
+        [args addObject:[[outputDocSetPath stringByStandardizingPath] stringByAppendingPathExtension:extension]];
         [args addObject:installedDocSetPath];
         
         // Run the task.
@@ -130,7 +132,10 @@
             if (error) *error = [NSError errorWithCode:GBErrorDocSetUtilIndexingFailed description:[NSString stringWithFormat:@"failed to read the xml template document in %@!", xmlTemplatePath] reason:task.lastStandardError];
             return NO;
         }
-        xmlString = [xmlString stringByReplacingOccurrencesOfString:@"${DOCSET_FEED_URL}" withString:self.settings.docsetFeedURL];
+        NSString *tarURL = self.settings.docsetPackageURL;
+        tarURL = [[tarURL stringByDeletingPathExtension] stringByAppendingPathExtension:extension];
+        
+        xmlString = [xmlString stringByReplacingOccurrencesOfString:@"${DOCSET_PACKAGE_URL}" withString:tarURL];
         xmlString = [xmlString stringByReplacingOccurrencesOfString:@"${DOCSET_FEED_VERSION}" withString:self.settings.projectVersion];
         result = [self writeString:xmlString toFile:[outputXMLPath stringByStandardizingPath] error:error];
         if(!result)

--- a/Templates/publish/xml-template.xml
+++ b/Templates/publish/xml-template.xml
@@ -1,4 +1,4 @@
 <entry>
   <version>${DOCSET_FEED_VERSION}</version>
-  <url>${DOCSET_FEED_URL}</url>
+  <url>${DOCSET_PACKAGE_URL}</url>
 </entry>


### PR DESCRIPTION
Sorry. Somehow this bug creeped in and the package URL wasn't getting generated properly for the xml (Dash) feed.
