### PR TITLE
Fixes a bug causing the xar-file URL to be incorrect

### DIFF
--- a/Generating/GBDocSetPublishGenerator.m
+++ b/Generating/GBDocSetPublishGenerator.m
@@ -71,6 +71,12 @@
 	
     if(self.settings.docsetFeedFormats & GBPublishedFeedFormatAtom)
     {
+        // typical atom enclosure url does not have an extension, add it if it doesn't
+        if (![url hasSuffix:@".xar"])
+        {
+            url = [url stringByAppendingPathExtension:@"xar"];
+        }
+        
         // Create command line arguments array.
         NSMutableArray *args = [NSMutableArray array];
         [args addObject:@"docsetutil"];


### PR DESCRIPTION
This causes problems since there is not supposed to be an extension anyway. Removing an extension from DTCoreText-1.2 causes the package name to be become DTCoreText-1.xar which is wrong.

Fixes #338
