### PR TITLE
Fixes links to doc index in companion documentation

### DIFF
--- a/Generating/GBHTMLTemplateVariablesProvider.m
+++ b/Generating/GBHTMLTemplateVariablesProvider.m
@@ -148,6 +148,7 @@
 	[page setObject:[self pageTitleForDocument:object] forKey:@"title"];
 	[page setObject:[path stringByAppendingPathComponent:@"css/styles.css"] forKey:@"cssPath"];
 	[page setObject:[path stringByAppendingPathComponent:@"css/stylesPrint.css"] forKey:@"cssPrintPath"];
+    [page setObject:[path stringByAppendingPathComponent:@"index.html"] forKey:@"documentationIndexPath"];
 	[self addFooterVarsToDictionary:page];
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
 	[result setObject:page forKey:@"page"];

--- a/Templates/html/document-template.html
+++ b/Templates/html/document-template.html
@@ -11,8 +11,8 @@
 	<body>
 		<header id="top_header">
 			<div id="library" class="hideInXcode">
-				{{#page}}<h1><a id="libraryTitle" href="../index.html">{{projectName}} {{strings/objectPage/libraryTitlePostfix}}</a></h1>
-				<a id="developerHome" href="../index.html">{{projectCompany}}</a>{{/page}}
+				{{#page}}<h1><a id="libraryTitle" href="{{documentationIndexPath}}">{{projectName}} {{strings/objectPage/libraryTitlePostfix}}</a></h1>
+				<a id="developerHome" href="{{documentationIndexPath}}">{{projectCompany}}</a>{{/page}}
 			</div>
 			
 			<div id="title" role="banner">


### PR DESCRIPTION
The template had a fixed relative link to the doc index as ../index.html which breaks for included docs. A fixed link cannot be used because the directory structure of included documentation is preserved.

We add a new string to the page dictionary which generates the correct relative link (in the same way the CSS links are created). This is used instead of the fixed link.

Fixes: #324
