### PR TITLE
`GBPublishedFeedFormatsFromNSString` should initialize `formats`

### DIFF
--- a/Application/GBApplicationSettingsProvider.m
+++ b/Application/GBApplicationSettingsProvider.m
@@ -50,7 +50,7 @@ NSString *NSStringFromGBHTMLAnchorFormat(GBHTMLAnchorFormat format) {
 GBPublishedFeedFormats GBPublishedFeedFormatsFromNSString(NSString *formatString) {
     // These items are comma delimited
     NSArray *formatItems = [[formatString lowercaseString] componentsSeparatedByString:@","];
-    GBPublishedFeedFormats formats;
+    GBPublishedFeedFormats formats = 0;
     if ([formatItems containsObject:@"xml"]) {
         formats = formats | GBPublishedFeedFormatXML;
     }


### PR DESCRIPTION
A trivial little change: `GBPublishedFeedFormatsFromNSString` is not currently initializing the `formats` variable. I'm initializing it to `0`. If you want to initialize it to something else (e.g. I don't know if you're initializing `self.settings.docsetFeedFormats` elsewhere), feel free, but to leave this local variable uninitialized and then proceeding to adjust the value will result in undefined behavior.
