### PR TITLE
Fix link content duplication when links are embedded inside other links

### DIFF
--- a/Testing/GBCommentsProcessor-PreprocessingTesting.m
+++ b/Testing/GBCommentsProcessor-PreprocessingTesting.m
@@ -661,6 +661,20 @@
 	assertThat(result6, is(@"[1]: something \"Class\""));
 }
 
+#pragma mark Links inside of links testing
+
+- (void) testStringByConvertingCrossReferencesInString_shouldIgnoreLinksInsideOtherLinks {
+    // setup
+    GBClassData *class = [GBTestObjectsRegistry classWithName:@"Class" methods:[GBTestObjectsRegistry classMethodWithNames:@"URLWithString", nil], nil];
+    GBStore *store = [GBTestObjectsRegistry storeWithObjects:class, nil];
+    GBCommentsProcessor *processor = [self processorWithStore:store context:class];
+	// execute
+	NSString *result1 = [processor stringByConvertingCrossReferencesInString:@"[Class URLWithString:@\"http://gentlebytes.com\"]" withFlags:0];
+	// verify
+	assertThat(result1, is(@"[Class URLWithString:@\"http://gentlebytes.com\"]"));
+}
+
+
 #pragma mark Creation methods
 
 - (GBCommentsProcessor *)defaultProcessor {


### PR DESCRIPTION
When a link falls within another link, such as a URL string within a method call, processing both would result in the processed URL being appended to the processed method call, duplicating the text from the URL. Instead, keep track of the links processed, and ignore a link if it's inside of a previously processed link.

Here's a test case which illustrates the problem:

``` objc
/**
`NSURL *baseURL = [NSURL URLWithString:@"http://example.com/v1/"]`
*/
@interface Fooclass : NSObject
@end
```

Result:

``` html
<p><code>NSURL *baseURL = [NSURL URLWithString:@"http://example.com/v1/"]</code>http://example.com/v1/<code>"]</code></p>
```

With patch:

``` html
<p><code>NSURL *baseURL = [NSURL URLWithString:@"http://example.com/v1/"]</code></p>
```

The test case does indeed cover this problem but certainly could be improved.
