### PR TITLE
Test suite: Fix compilation error

### DIFF
--- a/Testing/GBObjectsAssertor.m
+++ b/Testing/GBObjectsAssertor.m
@@ -212,7 +212,10 @@
 				argList = (char *)malloc(sizeof(char) * [expectedComps count]);
 				[expectedComps getObjects:(id *)argList];				
 			}
-			[self assertCommentComponents:argument.argumentDescription matchesValues:firstExpectedComp values:(__va_list_tag *)argList];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+			[self assertCommentComponents:argument.argumentDescription matchesValues:firstExpectedComp values:argList];
+#pragma clang diagnostic pop
 		}
 	}
 }


### PR DESCRIPTION
The cast to `__va_list_tag *` fails with an error on my system (OS X 10.8.4, Xcode 4.6.3). I've tried several other possibilities and was unable to find a way to make the cast in a way that does build. So, I removed it, and suppressed the warning.

Faking out a va_list is kind of dirty to begin with, so I think suppressing this warning is okay.

If there's a better fix I'd be happy to use that instead!

```
GBObjectsAssertor.m:215:103: error: use of undeclared identifier '__va_list_tag'
                        [self assertCommentComponents:argument.argumentDescription matchesValues:firstExpectedComp values:(__va_list_tag *)argList];
                                                                                                                           ^
GBObjectsAssertor.m:215:118: error: expected expression
                        [self assertCommentComponents:argument.argumentDescription matchesValues:firstExpectedComp values:(__va_list_tag *)argList];
```
