### PR TITLE
Make 'comment found' entries log at INFO level

### DIFF
--- a/Common/GBLog.h
+++ b/Common/GBLog.h
@@ -76,6 +76,7 @@ void GBLogUpdateResult(NSInteger result);
 // Macros that store given file/line info. Mostly used for better Xcode integration!
 #define GBLogXError(source,frmt,...) { [DDLog storeFilename:[source fullpath] line:[source lineNumber]]; GBLogError(frmt, ##__VA_ARGS__); }
 #define GBLogXWarn(source,frmt,...) { [DDLog storeFilename:[source fullpath] line:[source lineNumber]]; GBLogWarn(frmt, ##__VA_ARGS__); }
+#define GBLogXInfo(source,frmt,...) { [DDLog storeFilename:[source fullpath] line:[source lineNumber]]; GBLogInfo(frmt, ##__VA_ARGS__); }
 
 // Helper macros for logging exceptions. Note that we don't use formatting here as it would make the output unreadable
 // in higher level log formats. The information is already verbose enough!

--- a/Model/GBModelBase.m
+++ b/Model/GBModelBase.m
@@ -48,7 +48,7 @@
 	// Merge comment.
 	GBComment *theComment = [(GBModelBase *)source comment];
 	if (self.comment && theComment) {
-		GBLogXWarn(self.prefferedSourceInfo, @"%@: Comment found in %@ and %@!", self, self.comment.sourceInfo, theComment.sourceInfo);
+		GBLogXInfo(self.prefferedSourceInfo, @"%@: Comment found in %@ and %@", self, self.comment.sourceInfo, theComment.sourceInfo);
 		return;
 	}
 	if (!self.comment && theComment) self.comment = theComment;


### PR DESCRIPTION
For issue #363, this pull request makes 'comment found' items log at INFO level instead of WARN.

After this pull request is merged, the lines mentioned in that issue will look like the following (at `--verbose 4`):

```
...
INFO | BBProvisioningProfile: Comment found in BBProvisioningProfile.h@3 and BBProvisioningProfile.m@3
WARN | @propertyBBProvisioningProfile.filesystemPath is not documented!
...
```

At `--verbose 3`, the INFO line doesn't appear :)
