### PR TITLE
Removing the tooltips on class methods.

### DIFF
--- a/Templates/html/object-template.html
+++ b/Templates/html/object-template.html
@@ -314,7 +314,6 @@ Section TaskMethod
 <li>
 	<span class="tooltip">
 		<code><a href="{{htmlLocalReference}}">{{>TaskSelector}}</a></code>
-		{{#comment}}{{#hasShortDescription}}<span class="tooltip">{{#shortDescription}}{{>GBCommentComponent}}{{/shortDescription}}</span>{{/hasShortDescription}}{{/comment}}
 	</span>
 	{{#isProperty}}<span class="task-item-suffix">{{strings/objectTasks/property}}</span>{{/isProperty}}
 	{{#isRequired}}<span class="task-item-suffix">{{strings/objectTasks/requiredMethod}}</span>{{/isRequired}}


### PR DESCRIPTION
Removing the mouse hover tooltip on class methods since this is no longer coherent with Apple's documentation.
