### PR TITLE
Set up Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: objective-c
+before_install:
+    - brew update
+    - brew install xctool --HEAD
+script: rake test

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+desc "Run the Appledoc Tests"
+task :test do
+  ENV['GHUNIT_CLI'] = "1"
+  if system("xctool -workspace appledoc.xcworkspace -scheme AppledocTests")
+    puts "\033[0;32m** All tests executed successfully"
+  else
+    puts "\033[0;31m! Unit tests failed"
+    exit(-1)
+  end
+end
+
+task :default => 'test'

--- a/appledoc.xcodeproj/project.pbxproj
+++ b/appledoc.xcodeproj/project.pbxproj
@@ -1187,6 +1187,7 @@
 				733EA122122BDD020060CBDE /* Sources */,
 				733EA123122BDD020060CBDE /* Frameworks */,
 				D818BACD15203A9E00B26451 /* CopyFiles */,
+				9E9653391791A3DA0086251B /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1256,6 +1257,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		9E9653391791A3DA0086251B /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"$GHUNIT_CLI\" = \"\" ]; then\nexit 0\nfi\n\n$TARGET_BUILD_DIR/$EXECUTABLE_PATH";
+		};
 		B4D1FFE715FF60B7009736E2 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/appledoc.xcodeproj/xcshareddata/xcschemes/AppledocTests.xcscheme
+++ b/appledoc.xcodeproj/xcshareddata/xcschemes/AppledocTests.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0460"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "733EA124122BDD020060CBDE"
+               BuildableName = "AppledocTests.app"
+               BlueprintName = "AppledocTests"
+               ReferencedContainer = "container:appledoc.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "733EA124122BDD020060CBDE"
+            BuildableName = "AppledocTests.app"
+            BlueprintName = "AppledocTests"
+            ReferencedContainer = "container:appledoc.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "733EA124122BDD020060CBDE"
+            BuildableName = "AppledocTests.app"
+            BlueprintName = "AppledocTests"
+            ReferencedContainer = "container:appledoc.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "733EA124122BDD020060CBDE"
+            BuildableName = "AppledocTests.app"
+            BlueprintName = "AppledocTests"
+            ReferencedContainer = "container:appledoc.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/appledoc.xcworkspace/contents.xcworkspacedata
+++ b/appledoc.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:appledoc.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
I set up appledoc to work with Travis-CI, a continuous integration platform for open-source projects. It will automatically build and run tests on the active branches, and on each pull request. It integrates well with Github. It's a great starting point for avoiding regressions.

I've tested this on my fork, but there are a few steps to get this running on the main repository (the order is important):
1. Sign in to Travis CI using GitHub OAuth. Go to [Travis CI](http://travis-ci.org/) and follow the Sign In link at the top. GitHub will ask you to grant read and write access. Travis CI needs write access for setting up service hooks for your repositories when you request it, but it won't touch anything else.
2. Once you're signed in go to your [profile page](https://travis-ci.org/profile). You'll see a list of your repositories. Flip the on/off switch for appledoc.
3. Merge this pull request. The git push will trigger the first build.

More info on this commit:
- .travis.yml contains the instructions to Travis, which is to install xctool and then invoke rake.
- Rake sets an environment variable GHUNIT_CLI and builds the tests.
- The Run Script action I added to the target will run the tests as part of the build action, but only when that environment variable is set.

If you have rake installed, you can also run the tests locally by running `rake` from the project directory.
