### PR TITLE
Fixed bubble help (quick help) for Categories in Xcode 4.6.3, possible fix to issue #374

### DIFF
--- a/Generating/GBDocSetOutputGenerator.m
+++ b/Generating/GBDocSetOutputGenerator.m
@@ -391,8 +391,8 @@
 			objectName = [(GBClassData *)parent nameOfClass];
 			objectID = ([(GBMethodData *)object methodType] == GBMethodTypeClass) ? @"cl" : @"inst";
 		} else if ([parent isKindOfClass:[GBCategoryData class]]) {
-			objectName = [(GBCategoryData *)parent idOfCategory];
-			objectID = @"intf";
+			objectName = [(GBCategoryData *)parent nameOfClass];
+			objectID = @"inst";
 		} else {
 			objectName = [(GBProtocolData *)parent nameOfProtocol];
 			objectID = @"intf";


### PR DESCRIPTION
I've checked on XCode 4.6.3, it absolutely need both the class name and the objectID changed to function. Also, so see the changes in Category documentation with the quick help, a restart of XCode is necessary. Apparently XCode does more caching that just the .docset.

I don't have the means to regression test this for anonymous categories (something hidden in `nameOfClass`), but for my needs I don't need those (anonymous categories are private anyway). I just wanted to fix it with minimum side effects to be able to document my shared lib.
