### PR TITLE
Fix unexpected warning on typedef enum without { } 

### DIFF
--- a/Parsing/GBObjectiveCParser.m
+++ b/Parsing/GBObjectiveCParser.m
@@ -503,8 +503,9 @@
     else
     {
         BOOL isRegularEnum = [[self.tokenizer lookahead:1] matches:@"enum"];
-    
-        if(isRegularEnum)
+        BOOL isCurlyBrace = [[self.tokenizer lookahead:2] matches:@"{"];
+        
+        if(isRegularEnum && isCurlyBrace)
         {
             GBSourceInfo *startInfo = [tokenizer sourceInfoForCurrentToken];
             GBLogXWarn(startInfo, @"unsupported typedef enum at %@!", startInfo);


### PR DESCRIPTION
(related to issue #2)

/*\* This should not trigger an undefined warning */
# define XYZ typedef enum bla;

/*\* This should */
typedef enum { One, Two } xyz;

/*\* This should not */
 #ifndef NS_ENUM
 #define NS_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
 #endif
