### PR TITLE
Add Docset usage tips to README

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -65,6 +65,16 @@ To keep up to date, just go to Terminal and cd into appledoc directory, issue `g
 
 If you also want to compile and run AppledocTests (unit tests) target, you need to copy all the frameworks indicated within Libraries & Frameworks group to shared frameworks directory before building unit tests target! This is not required for building the appledoc tool itself.
 
+Docset usage tips
+-----------------
+
+Pre-generated documentation and docsets for most Cocoa frameworks are available at:
+- [CocoaDocs](http://cocoadocs.org)
+
+Once you have a docset, you might want to use it with a documentation browser:
+- [Xcode](https://developer.apple.com/xcode/)
+- [Dash](http://kapeli.com/dash)
+
 Troubleshooting
 ---------------
 
@@ -89,7 +99,6 @@ Minimum system requirements
 
 - Xcode 4.5 or greater for compiling
 - OS X 10.7 for compiling and running
-
 
 LICENSE
 =======


### PR DESCRIPTION
I'm not sure if this is appropriate or not, but just in case...

I thought it would be great to have a "Docset usage tips" section in the Readme, which would mention tools like CocoaDocs or Dash (I'm the developer behind Dash as you already know so yep I'm promoting Dash with this pull request).

The general idea is that docsets are really useful when you use them with a documentation browser, and users of appledoc should know that various documentation browsers are available.

In the case of CocoaDocs, users should know that docsets are already available for most Cocoa frameworks, so they might avoid using appledoc if the docs they want are already available on CocoaDocs.
