### PR TITLE
Separated finalizing a docset from installing it.

### DIFF
--- a/Application/GBAppledocApplication.m
+++ b/Application/GBAppledocApplication.m
@@ -37,6 +37,7 @@ static NSString *kGBArgCompanyIdentifier = @"company-id";
 static NSString *kGBArgCleanOutput = @"clean-output";
 static NSString *kGBArgCreateHTML = @"create-html";
 static NSString *kGBArgCreateDocSet = @"create-docset";
+static NSString *kGBArgFinalizeDocSet = @"finalize-docset";
 static NSString *kGBArgInstallDocSet = @"install-docset";
 static NSString *kGBArgPublishDocSet = @"publish-docset";
 static NSString *kGBArgHTMLAnchorFormat = @"html-anchors";
@@ -270,6 +271,7 @@ static NSString *kGBArgHelp = @"help";
 		{ kGBArgCleanOutput,												0,		DDGetoptNoArgument },
 		{ kGBArgCreateHTML,													'h',	DDGetoptNoArgument },
 		{ kGBArgCreateDocSet,												'd',	DDGetoptNoArgument },
+		{ kGBArgFinalizeDocSet,												0,	DDGetoptNoArgument },
 		{ kGBArgInstallDocSet,												'n',	DDGetoptNoArgument },
 		{ kGBArgPublishDocSet,												'u',	DDGetoptNoArgument },
         { kGBArgHTMLAnchorFormat,                                           0,      DDGetoptRequiredArgument },
@@ -750,6 +752,7 @@ static NSString *kGBArgHelp = @"help";
 	self.settings.createHTML = value; 
 	if (!value) {
 		self.settings.createDocSet = NO;
+		self.settings.finalizeDocSet = NO;
 		self.settings.installDocSet = NO;
 		self.settings.publishDocSet = NO;
 	}
@@ -759,8 +762,20 @@ static NSString *kGBArgHelp = @"help";
 	if (value) {
 		self.settings.createHTML = YES;
 	} else {
+		self.settings.finalizeDocSet = NO;
 		self.settings.installDocSet = NO;
 		self.settings.publishDocSet = NO;
+	}
+}
+- (void)setFinalizeDocset:(BOOL)value {
+	self.settings.finalizeDocSet = value;
+	if (value) {
+		self.settings.createHTML = YES;
+		self.settings.createDocSet = YES;
+		self.settings.installDocSet = NO;
+
+	//	} else {
+	//		self.settings.publishDocSet = NO;
 	}
 }
 - (void)setInstallDocset:(BOOL)value { 
@@ -768,7 +783,8 @@ static NSString *kGBArgHelp = @"help";
 	if (value) {
 		self.settings.createHTML = YES;
 		self.settings.createDocSet = YES;
-		
+		self.settings.finalizeDocSet = YES;
+
     //	} else {
     //		self.settings.publishDocSet = NO;
 	}
@@ -787,6 +803,7 @@ static NSString *kGBArgHelp = @"help";
 - (void)setNoCleanOutput:(BOOL)value { self.settings.cleanupOutputPathBeforeRunning = !value; }
 - (void)setNoCreateHtml:(BOOL)value { [self setCreateHtml:!value]; }
 - (void)setNoCreateDocset:(BOOL)value { [self setCreateDocset:!value]; }
+- (void)setNoFinalizeDocset:(BOOL)value { [self setFinalizeDocset:!value]; }
 - (void)setNoInstallDocset:(BOOL)value { [self setInstallDocset:!value]; }
 - (void)setNoPublishDocset:(BOOL)value { [self setPublishDocset:!value]; }
 

--- a/Application/GBApplicationSettingsProvider.h
+++ b/Application/GBApplicationSettingsProvider.h
@@ -223,16 +223,27 @@ NSString *NSStringFromGBPublishedFeedFormats(GBPublishedFeedFormats format);
  If `YES`, HTML files from html subdirectory in `outputPath` are moved to proper subdirectory within docset output files, then helper files are generated from parsed data. Documentation set files are also indexed. If `NO`, HTML files are left in the output path.
  
  @see createHTML
+ @see finalizeDocSet
  @see installDocSet
  @see publishDocSet
  */
 @property (assign) BOOL createDocSet;
 
-/** Specifies whether the documentation set should be installed or not.
- 
- If `YES`, temporary files used for indexing and removed, then documentation set bundle is created from the files from docset output path and is moved to `docsetInstallPath`. If `NO`, all documentation set files are left in output path.
- 
+/** Specifies whether the documentation set should be created at the install path or not.
+
+ If `YES`, temporary files used for indexing are removed, then documentation set bundle is created from the files from docset output path and is moved to `docsetInstallPath`. If `NO`, all documentation set files are left in output path.
+
  @see createDocSet
+ @see installDocSet
+ */
+@property BOOL finalizeDocSet;
+
+/** Specifies whether the documentation set should be installed or not.
+
+ If `YES`, the finalized documentation set is installed to Xcode. If `NO`, the documentation set is left for the user to install or otherwise dispose of.
+
+ @see createDocSet
+ @see finalizeDocSet
  @see publishDocSet
  */
 @property (assign) BOOL installDocSet;

--- a/Generating/GBDocSetFinalizeGenerator.h
+++ b/Generating/GBDocSetFinalizeGenerator.h
@@ -1,0 +1,15 @@
+//
+//  GBDocSetFinalizeGenerator.h
+//  appledoc
+//
+//  Created by Tomaz Kragelj on 18.1.11.
+//  Copyright 2011 Gentle Bytes. All rights reserved.
+//
+
+#import "GBOutputGenerator.h"
+
+/** Concrete `GBOutputGenerator` that delivers generated documentation set to install path.
+ */
+@interface GBDocSetFinalizeGenerator : GBOutputGenerator
+
+@end

--- a/Generating/GBDocSetFinalizeGenerator.m
+++ b/Generating/GBDocSetFinalizeGenerator.m
@@ -1,0 +1,54 @@
+//
+//  GBDocSetFinalizeGenerator.m
+//  appledoc
+//
+//  Created by Tomaz Kragelj on 18.1.11.
+//  Copyright 2011 Gentle Bytes. All rights reserved.
+//
+
+#import "GBApplicationSettingsProvider.h"
+#import "GBStore.h"
+#import "GBTask.h"
+#import "GBDocSetFinalizeGenerator.h"
+
+#pragma mark -
+
+@implementation GBDocSetFinalizeGenerator
+
+#pragma Generation handling
+
+- (BOOL)generateOutputWithStore:(id)store error:(NSError **)error {
+	NSParameterAssert(self.previousGenerator != nil);
+	GBLogInfo(@"Finalizing DocSet...");
+	
+	// Prepare for run.
+	if (![super generateOutputWithStore:store error:error]) return NO;
+	
+	// Prepare source and destination paths and file names.
+	NSString *sourceUserPath = self.inputUserPath;
+	NSString *destUserPath = self.outputUserPath;
+	NSString *sourcePath = [sourceUserPath stringByStandardizingPath];
+	NSString *destPath = [destUserPath stringByStandardizingPath];
+	
+	// Create destination directory and move files to it.
+	GBLogVerbose(@"Moving DocSet files from '%@' to '%@'...", sourceUserPath, destUserPath);
+	if (![self initializeDirectoryAtPath:destUserPath error:error]) {
+		GBLogWarn(@"Failed initializing DocSet installation directory '%@'!", destUserPath);
+		return NO;
+	}
+	if (![self copyOrMoveItemFromPath:sourcePath toPath:destPath error:error]) {
+		GBLogWarn(@"Failed moving DocSet files from '%@' to '%@'!", sourceUserPath, destUserPath);
+		return NO;
+	}
+
+	return YES;
+}
+
+#pragma mark Overriden methods
+
+- (NSString *)outputUserPath {
+	// Note that we use custom location, so can't rely on default implementation using outputSubpath!
+	return [self.settings.docsetInstallPath stringByAppendingPathComponent:self.settings.docsetBundleFilename];
+}
+
+@end

--- a/Generating/GBDocSetInstallGenerator.m
+++ b/Generating/GBDocSetInstallGenerator.m
@@ -28,23 +28,10 @@
 	// Prepare for run.
 	if (![super generateOutputWithStore:store error:error]) return NO;
 	
-	// Prepare source and destination paths and file names.
+	// Prepare source path and file name.
 	NSString *sourceUserPath = self.inputUserPath;
-	NSString *destUserPath = self.outputUserPath;
 	NSString *sourcePath = [sourceUserPath stringByStandardizingPath];
-	NSString *destPath = [destUserPath stringByStandardizingPath];
-	
-	// Create destination directory and move files to it.
-	GBLogVerbose(@"Moving DocSet files from '%@' to '%@'...", sourceUserPath, destUserPath);
-	if (![self initializeDirectoryAtPath:destUserPath error:error]) {
-		GBLogWarn(@"Failed initializing DocSet installation directory '%@'!", destUserPath);
-		return NO;
-	}
-	if (![self copyOrMoveItemFromPath:sourcePath toPath:destPath error:error]) {
-		GBLogWarn(@"Failed moving DocSet files from '%@' to '%@'!", sourceUserPath, destUserPath);
-		return  NO;
-	}
-	
+
 	// Prepare text file with message on the output path to avoid confusion when empty path is found.
 	[self touchInstallMessageFile];
 	
@@ -52,7 +39,7 @@
 	GBLogVerbose(@"Installing DocSet to Xcode...");
 	NSMutableString* installScript  = [NSMutableString string];
 	[installScript appendString:@"tell application \"Xcode\"\n"];
-	[installScript appendFormat:@"\tload documentation set with path \"%@\"\n", destPath];
+	[installScript appendFormat:@"\tload documentation set with path \"%@\"\n", sourcePath];
 	[installScript appendString:@"end tell"];
 	
 	// Run the AppleScript for loading the documentation into the Xcode.
@@ -82,8 +69,8 @@
 #pragma mark Overriden methods
 
 - (NSString *)outputUserPath {
-	// Note that we use custom location, so can't rely on default implementation using outputSubpath!
-	return [self.settings.docsetInstallPath stringByAppendingPathComponent:self.settings.docsetBundleFilename];
+	// Our output is the documentation set we just installed. (We have to output it in case publishing is in the queue next.)
+	return self.inputUserPath;
 }
 
 @end

--- a/Generating/GBGenerator.m
+++ b/Generating/GBGenerator.m
@@ -10,6 +10,7 @@
 #import "GBApplicationSettingsProvider.h"
 #import "GBHTMLOutputGenerator.h"
 #import "GBDocSetOutputGenerator.h"
+#import "GBDocSetFinalizeGenerator.h"
 #import "GBDocSetInstallGenerator.h"
 #import "GBDocSetPublishGenerator.h"
 #import "GBGenerator.h"
@@ -60,6 +61,7 @@
 	[self.outputGenerators addObject:[GBHTMLOutputGenerator generatorWithSettingsProvider:self.settings]];
 	if (!self.settings.createDocSet) return;
 	[self.outputGenerators addObject:[GBDocSetOutputGenerator generatorWithSettingsProvider:self.settings]];
+	[self.outputGenerators addObject:[GBDocSetFinalizeGenerator generatorWithSettingsProvider:self.settings]];
 	if (self.settings.installDocSet) {
         [self.outputGenerators addObject:[GBDocSetInstallGenerator generatorWithSettingsProvider:self.settings]];
     }

--- a/appledoc.xcodeproj/project.pbxproj
+++ b/appledoc.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		31DBC2AE18060C3C002AFE9F /* GBDocSetFinalizeGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 31DBC2AD18060C3C002AFE9F /* GBDocSetFinalizeGenerator.m */; };
+		31DBC2AF18060EFF002AFE9F /* GBDocSetFinalizeGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 31DBC2AD18060C3C002AFE9F /* GBDocSetFinalizeGenerator.m */; };
 		7307B311124A1929007EC6B8 /* GBObjectiveCParser-SectionsParsingTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = 7307B310124A1929007EC6B8 /* GBObjectiveCParser-SectionsParsingTesting.m */; };
 		7307B31A124A1C2E007EC6B8 /* GBMethodSectionData.m in Sources */ = {isa = PBXBuildFile; fileRef = 7307B319124A1C2E007EC6B8 /* GBMethodSectionData.m */; };
 		7307B31B124A1C2E007EC6B8 /* GBMethodSectionData.m in Sources */ = {isa = PBXBuildFile; fileRef = 7307B319124A1C2E007EC6B8 /* GBMethodSectionData.m */; };
@@ -259,6 +261,8 @@
 
 /* Begin PBXFileReference section */
 		08FB779EFE84155DC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		31DBC2AC18060C3C002AFE9F /* GBDocSetFinalizeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GBDocSetFinalizeGenerator.h; sourceTree = "<group>"; };
+		31DBC2AD18060C3C002AFE9F /* GBDocSetFinalizeGenerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GBDocSetFinalizeGenerator.m; sourceTree = "<group>"; };
 		7307B310124A1929007EC6B8 /* GBObjectiveCParser-SectionsParsingTesting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "GBObjectiveCParser-SectionsParsingTesting.m"; sourceTree = "<group>"; };
 		7307B318124A1C2E007EC6B8 /* GBMethodSectionData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GBMethodSectionData.h; sourceTree = "<group>"; };
 		7307B319124A1C2E007EC6B8 /* GBMethodSectionData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GBMethodSectionData.m; sourceTree = "<group>"; };
@@ -783,6 +787,8 @@
 				739AD62E1255D8CB00B642C3 /* GBHTMLTemplateVariablesProvider.m */,
 				731872C312A3B75C0035509F /* GBDocSetOutputGenerator.h */,
 				731872C412A3B75C0035509F /* GBDocSetOutputGenerator.m */,
+				31DBC2AC18060C3C002AFE9F /* GBDocSetFinalizeGenerator.h */,
+				31DBC2AD18060C3C002AFE9F /* GBDocSetFinalizeGenerator.m */,
 				7335F72912E58DCC0094F72E /* GBDocSetInstallGenerator.h */,
 				7335F72A12E58DCC0094F72E /* GBDocSetInstallGenerator.m */,
 				7335F72C12E58E160094F72E /* GBDocSetPublishGenerator.h */,
@@ -1373,6 +1379,7 @@
 				733EA184122BE1750060CBDE /* NSString+GBString.m in Sources */,
 				732E6CBE12DF03A2009DD6E0 /* NSArray+GBArray.m in Sources */,
 				733EA185122BE17A0060CBDE /* GBIvarData.m in Sources */,
+				31DBC2AF18060EFF002AFE9F /* GBDocSetFinalizeGenerator.m in Sources */,
 				733EA186122BE17A0060CBDE /* GBIvarsProvider.m in Sources */,
 				733EA187122BE17B0060CBDE /* GBMethodArgument.m in Sources */,
 				733EA188122BE17B0060CBDE /* GBMethodData.m in Sources */,
@@ -1513,6 +1520,7 @@
 				7359B167129A5A0700F67AD1 /* GRMustacheURLTemplateLoader.m in Sources */,
 				7359B169129A5A0700F67AD1 /* GRMustacheVariableElement.m in Sources */,
 				7359B16B129A5A0700F67AD1 /* GRMustacheVersion.m in Sources */,
+				31DBC2AE18060C3C002AFE9F /* GBDocSetFinalizeGenerator.m in Sources */,
 				73F568BF12A22A7900A72BB2 /* DDASLLogger.m in Sources */,
 				73F568C112A22A7900A72BB2 /* DDFileLogger.m in Sources */,
 				73F568C312A22A7900A72BB2 /* DDLog.m in Sources */,


### PR DESCRIPTION
By finalizing, I mean delivering it to the install path. By installing it, I mean handing it to Xcode.

This distinction enables, for example, making an application that delivers a finished docset wherever the user wants it, as directed by a Save panel, without necessarily implicitly adding it to Xcode.

I am making such an application in another branch. If this pull request is accepted, I can then use the new --finalize-docset flag in the application.
