### PR TITLE
Fixed parameter parsing error for command-line options with space

### DIFF
--- a/install-appledoc.sh
+++ b/install-appledoc.sh
@@ -29,7 +29,7 @@ do
 		t)
 		   INSTALL_TEMPLATES="YES"
            echo "arg is = $OPTARG"
-		   if [ $OPTARG != "default" ]; then
+		   if [ "$OPTARG" != "default" ]; then
 		      TEMPLATES_DIR=$OPTARG
 		   fi
 		   ;;


### PR DESCRIPTION
when i run this script:
“sudo ./install-appledoc.sh -b /usr/bin -t ~/Library/Application\ Support/appledoc/ “

an error occurred.
“install-appledoc.sh: line 32: [: too many arguments”
