### PR TITLE
Fix for issue #38: Allow single-line comment *after* the documented line

### DIFF
--- a/Parsing/GBTokenizer.h
+++ b/Parsing/GBTokenizer.h
@@ -202,4 +202,13 @@
  */
 @property (readonly) GBComment *previousComment;
 
+
+/** Returns a "postfix" comment found between the start token and the current token.
+
+  @param startToken start of the current parsing entity.
+  @see lastComment
+  @see previousComment
+ */
+- (GBComment *)postfixCommentFrom:(PKToken *)startToken;
+
 @end

--- a/Testing/GBTokenizerTesting.m
+++ b/Testing/GBTokenizerTesting.m
@@ -420,6 +420,28 @@
 	assertThat(tokenizer.lastComment, is(nil));
 }
 
+- (void)testPostfixComment_shouldDetectSimplePostfixComment {
+	// setup & execute
+	GBApplicationSettingsProvider *settings = [GBTestObjectsRegistry realSettingsProvider];
+	GBTokenizer *tokenizer = [GBTokenizer tokenizerWithSource:[PKTokenizer tokenizerWithString:@"typedef NS_ENUM(NSUInteger, e) {\nVALUE1,   ///< postfix1\nVALUE2 };"] filename:@"file" settings:settings];
+	// verify
+   [tokenizer consume:8];
+   PKToken *startToken = tokenizer.currentToken;
+   [tokenizer consume:6];
+   assertThat([tokenizer postfixCommentFrom:startToken].stringValue, is(@"postfix1"));
+}
+
+- (void)testPostfixComment_shouldDetectMultilinePostfixComment {
+	// setup & execute
+	GBApplicationSettingsProvider *settings = [GBTestObjectsRegistry realSettingsProvider];
+	GBTokenizer *tokenizer = [GBTokenizer tokenizerWithSource:[PKTokenizer tokenizerWithString:@"typedef NS_ENUM(NSUInteger, e) {\nVALUE1,   ///< postfix1\n///< postfix2\nVALUE2 };"] filename:@"file" settings:settings];
+	// verify
+   [tokenizer consume:8];
+   PKToken *startToken = tokenizer.currentToken;
+   [tokenizer consume:7];
+   assertThat([tokenizer postfixCommentFrom:startToken].stringValue, is(@"postfix1\npostfix2"));
+}
+
 #pragma mark Miscellaneous methods
 
 - (void)testResetComments_shouldResetCommentValues {


### PR DESCRIPTION
Fix for issue #38

This changeset implements postfix comments "///<" for most elements:
- property
- -/+ method declaration
- -/+ method definition
- NS_ENUM/NS_OPTION typedef
- NE_ENUM/NS_OPTION constants

Multi line postfix comments are supported within above elements.

Postfix comments are ignored for classes, interfaces, protocols, etc.

If both, a normal (prefix) and a postfix comment is available, the postfix
comment is ignored.
