### PR TITLE
escape continuous '.' from footer.

### DIFF
--- a/Generating/GBHTMLTemplateVariablesProvider.m
+++ b/Generating/GBHTMLTemplateVariablesProvider.m
@@ -278,7 +278,12 @@
 }
 
 - (void)addFooterVarsToDictionary:(NSMutableDictionary *)dict {
-	[dict setObject:self.settings.projectCompany forKey:@"copyrightHolder"];
+    NSString* projectCompanyForFooter = self.settings.projectCompany;
+    if ([projectCompanyForFooter hasSuffix:@"."])
+    {
+        projectCompanyForFooter = [projectCompanyForFooter substringToIndex:projectCompanyForFooter.length - 1];
+    }
+	[dict setObject:projectCompanyForFooter forKey:@"copyrightHolder"];
 	[dict setObject:[self.settings stringByReplacingOccurencesOfPlaceholdersInString:kGBTemplatePlaceholderYear] forKey:@"copyrightDate"];
 	[dict setObject:[self.settings stringByReplacingOccurencesOfPlaceholdersInString:kGBTemplatePlaceholderUpdateDate] forKey:@"lastUpdatedDate"];
 }


### PR DESCRIPTION
escape continuous '.' from footer. (footer is already setted '.' into template)
ex ) company name is 'Aaa Co, Ltd.' -> '(c) 2014 AAA Co, Ltd.. All rights reserved.'
