### PR TITLE
Fix issue of static style sheet and js url for docs

### DIFF
--- a/Generating/GBHTMLTemplateVariablesProvider.m
+++ b/Generating/GBHTMLTemplateVariablesProvider.m
@@ -185,9 +185,10 @@
 	NSString *path = [self.settings htmlRelativePathToIndexFromObject:object];
 	NSMutableDictionary *page = [NSMutableDictionary dictionary];
 	[page setObject:[self pageTitleForDocument:object] forKey:@"title"];
-	[page setObject:[path stringByAppendingPathComponent:@"css/styles.css"] forKey:@"cssPath"];
-	[page setObject:[path stringByAppendingPathComponent:@"css/stylesPrint.css"] forKey:@"cssPrintPath"];
-    [page setObject:[path stringByAppendingPathComponent:@"index.html"] forKey:@"documentationIndexPath"];
+	[page setObject:[path stringByAppendingPathComponent:@"css/style.css"] forKey:@"cssPath"];
+	[page setObject:[path stringByAppendingPathComponent:@"css/stylePrint.css"] forKey:@"cssPrintPath"];
+	[page setObject:[path stringByAppendingPathComponent:@"js/script.js"] forKey:@"jsPath"];
+  [page setObject:[path stringByAppendingPathComponent:@"index.html"] forKey:@"documentationIndexPath"];
 	[self addFooterVarsToDictionary:page];
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
 	[result setObject:page forKey:@"page"];

--- a/Templates/html/document-template.html
+++ b/Templates/html/document-template.html
@@ -5,7 +5,7 @@
 
 	<title>{{page.title}}</title>
 
-	<link rel="stylesheet" href="css/style.css">
+	<link rel="stylesheet" href="{{page.cssPath}}">
 	<meta name="viewport" content="initial-scale=1, maximum-scale=1.4">
 	{{#strings.appledocData}}<meta name="generator" content="{{tool}} {{version}} (build {{build}})">{{/strings.appledocData}}
 </head>
@@ -14,11 +14,11 @@
 		<div class="container" class="hide-in-xcode">
 			{{#page}}
 			<h1 id="library-title">
-				<a href="index.html">{{projectName}} {{strings.objectPage.libraryTitlePostfix}}</a>
+				<a href="{{page.documentationIndexPath}}">{{projectName}} {{strings.objectPage.libraryTitlePostfix}}</a>
 			</h1>
 
 			<p id="developer-home">
-				<a href="index.html">{{projectCompany}}</a>
+				<a href="{{page.documentationIndexPath}}">{{projectCompany}}</a>
 			</p>
 			{{/page}}
 		</div>
@@ -57,7 +57,7 @@
 		</div>
 	</article>
 
-	<script src="js/script.js"></script>
+	<script src="{{page.jsPath}}"></script>
 </body>
 </html>
 


### PR DESCRIPTION
Update the document template to use relative paths for css, index, and js.

The paths in the template variables referenced the wrong style sheet. As well, the javascript path was never included. When the template '/' issue has been fixed by a previous commit the template insertion of css, index, and js was removed.