### PR TITLE
Fix link in doc template, js screen flicker, non closing section

### DIFF
--- a/Templates/html/document-template.html
+++ b/Templates/html/document-template.html
@@ -71,5 +71,5 @@ Section GBCommentComponent
 EndSection
 
 Section Navigation
-<li><a href="index.html">Home</a></li>
+<li><a href="{{page.documentationIndexPath}}">Home</a></li>
 EndSection

--- a/Templates/html/js/script.js
+++ b/Templates/html/js/script.js
@@ -46,10 +46,11 @@ function fixScrollPosition(element) {
 		info.style.height = (infoContainer.clientHeight + 40) + "px";
 		fixScrollPosition(element);
 		element.classList.toggle("hide");
-
+		if (element.classList.contains("hide")) {
+			e.preventDefault();
+		}
 		setTimeout(function() {
 			element.classList.remove("animating");
-			info.style.height = "auto";
 		}, 300);
 	});
 });


### PR DESCRIPTION
The document template had a link to an relative index.html and since the folder structure is not know, by default it should likely point back to the top document.

While clicking on links in the class files, the section drop down animation would flicker after it was presented. Removing the setting of info.style.height to auto fixed that issue. A new issue was also found where if a user clicked on a drop down section, then a second drop down section, then the first, the first drop down section would not close. This was due to the hashChange listener being called. In order to prevent this, when an item is being hid we prevent the URI from changing.