### PR TITLE
Fixing a crash when using --docset-xml-filename parameter

### DIFF
--- a/Application/GBAppledocApplication.m
+++ b/Application/GBAppledocApplication.m
@@ -884,7 +884,7 @@ static char *kGBArgHelp = "help";
 
 - (void)setDocsetBundleFilename:(NSString *)value { self.settings.docsetBundleFilename = value; }
 - (void)setDocsetAtomFilename:(NSString *)value { self.settings.docsetAtomFilename = value; }
-- (void)setDocsetXMLFilename:(NSString *)value { self.settings.docsetXMLFilename = value; }
+- (void)setDocsetXmlFilename:(NSString *)value { self.settings.docsetXMLFilename = value; }
 - (void)setDocsetPackageFilename:(NSString *)value { self.settings.docsetPackageFilename = value; }
 
 @synthesize additionalInputPaths;

--- a/Testing/GBApplicationTesting.m
+++ b/Testing/GBApplicationTesting.m
@@ -599,9 +599,6 @@
 			// get the key corresponding to the argument
 			NSString *key = [DDGetoptLongParser optionToKey:arg];
             
-            // When passed --docset-xml-filename, +[DDGetoptLongParser keyFromOption:] will
-            // return docsetXmlFilename but we need instead of docsetXMLFilename.
-            key = [key stringByReplacingOccurrencesOfString:@"Xml" withString:@"XML"];
             key = [key stringByReplacingOccurrencesOfString:@"xcrun" withString:@"xCRun"];
 			
 			// if we have a value following, use it for KVC, otherwise just send YES


### PR DESCRIPTION
DDCliApplication requires camel-case naming for parameter setters. A previous fix appears to have addressed this by fixing-up the test cases and not the application itself. This change reverses that workaround and correctly names the setter in CBAppledocApplication.