### PR TITLE
Fix parser error on block nullability and include block content on Block pages

### DIFF
--- a/Parsing/GBObjectiveCParser.m
+++ b/Parsing/GBObjectiveCParser.m
@@ -499,7 +499,28 @@
                      [argName appendString: [[self.tokenizer currentToken] stringValue]];
                      [tokenizer consume:1];
                  }
-                 
+               
+                 while([[self.tokenizer currentToken] matches:@"__nonnull"])
+                 {
+                   [argName appendString: [[self.tokenizer currentToken] stringValue]];
+                   [argName appendString:@" "];
+                   [tokenizer consume:1];
+                 }
+
+                while([[self.tokenizer currentToken] matches:@"__nullable"])
+                 {
+                   [argName appendString: [[self.tokenizer currentToken] stringValue]];
+                   [argName appendString:@" "];
+                   [tokenizer consume:1];
+                 }
+
+                 while([[self.tokenizer currentToken] matches:@"__null_unspecified"])
+                 {
+                   [argName appendString: [[self.tokenizer currentToken] stringValue]];
+                   [argName appendString:@" "];                   
+                   [tokenizer consume:1];
+                 }
+               
                  NSString *tokenString = [[self.tokenizer currentToken] stringValue];
                  if (tokenString) {
                      [argName appendString:tokenString];

--- a/Templates/html/object-template.html
+++ b/Templates/html/object-template.html
@@ -143,6 +143,12 @@
                     {{/prefferedSourceInfo}}
                     {{/comment}}
                     {{/typedefEnum}}
+                    
+          {{#typedefBlock}}
+          <a title="{{strings.objectMethods.blockDefTitle}}" name="instance_methods"></a>
+          <h4 class="method-subtitle parameter-title">{{strings.objectMethods.blockDefTitle}}</h4>
+          {{>BlocksDefList}}
+          {{/typedefBlock}}
 				</main>
 
 				<footer>
@@ -279,6 +285,55 @@ EndSection
 Section GBCommentComponentsList
 {{#components}}{{>GBCommentComponent}}{{/components}}
 EndSection
+
+Section BlocksDefList
+<h3 class="subsubtitle method-title">{{nameOfBlock}}</h3>
+{{#comment}}
+{{#hasShortDescription}}
+<div class="method-subsection brief-description">
+  {{#shortDescription}}{{>GBCommentComponent}}{{/shortDescription}}
+</div>
+{{/hasShortDescription}}
+{{/comment}}
+
+<code>typedef {{returnType}} (^{{nameOfBlock}}) ({{&htmlParameterList}})</code>
+  
+  {{#comment}}
+  {{#hasLongDescription}}
+  <div class="method-subsection discussion-section">
+  <h4 class="method-subtitle">{{strings.objectMethods.discussionTitle}}</h4>
+  {{#longDescription}}{{>GBCommentComponentsList}}{{/longDescription}}
+  </div>
+  {{/hasLongDescription}}
+  {{/comment}}
+  
+  {{#comment}}
+  {{#hasAvailability}}
+  <div class="method-subsection availability">
+  <h4 class="method-subtitle parameter-title">{{strings.objectMethods.availability}}</h4>
+  {{#availability}}{{>GBCommentComponentsList}}{{/availability}}
+  </div>
+  {{/hasAvailability}}
+  
+  {{#hasRelatedItems}}
+  <div class="method-subsection see-also-section">
+  <h4 class="method-subtitle">{{strings.objectMethods.seeAlsoTitle}}</h4>
+  <ul>
+  {{#relatedItems.components}}
+  <li><code>{{>GBCommentComponent}}</code></li>
+  {{/relatedItems.components}}
+  </ul>
+  </div>
+  {{/hasRelatedItems}}
+  
+  {{#prefferedSourceInfo}}
+  <div class="method-subsection declared-in-section">
+  <h4 class="method-subtitle">{{strings.objectMethods.declaredInTitle}}</h4>
+  <code class="declared-in-ref">{{filename}}</code><br />
+  </div>
+  {{/prefferedSourceInfo}}
+  {{/comment}}
+  EndSection
 
 Section Constant
 <dt><a name="{{htmlReferenceName}}" title="{{name}}"></a><code>{{name}}</code></dt>


### PR DESCRIPTION
Xcode 6.3 introduces nullability for parameters.

https://developer.apple.com/swift/blog/?id=25

Nullability on typedef'd blocks causes the rest of the file not to be processed. The following code appends and consumes the nullability parameters. It also includes the Block code back into the templates (not sure why it was deleted).