### PR TITLE
brew install appledoc22

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -45,7 +45,7 @@ It compiles appledoc and installs its binary to /usr/local/bin and templates (if
 	
 **Alternatively with Homebrew:**
 
-    brew install appledoc
+    brew install appledoc22
 
 Homebrew does not install templates by default.
 


### PR DESCRIPTION
Homebrew now splits appledoc brews by release.