### PR TITLE
Removing Xcode warnings

### DIFF
--- a/Common/ThirdParty/DDMinizip/other/crypt.h
+++ b/Common/ThirdParty/DDMinizip/other/crypt.h
@@ -32,7 +32,7 @@
 /***********************************************************************
  * Return the next byte in the pseudo-random sequence
  */
-static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab)
+static int decrypt_byte(unsigned long* pkeys)
 {
     unsigned temp;  /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
                      * unpredictable manner on 16-bit systems; not a problem
@@ -74,10 +74,10 @@ static void init_keys(const char* passwd,unsigned long* pkeys,const unsigned lon
 }
 
 #define zdecode(pkeys,pcrc_32_tab,c) \
-    (update_keys(pkeys,pcrc_32_tab,c ^= decrypt_byte(pkeys,pcrc_32_tab)))
+    (update_keys(pkeys,pcrc_32_tab,c ^= decrypt_byte(pkeys)))
 
 #define zencode(pkeys,pcrc_32_tab,c,t) \
-    (t=decrypt_byte(pkeys,pcrc_32_tab), update_keys(pkeys,pcrc_32_tab,c), t^(c))
+    (t=decrypt_byte(pkeys), update_keys(pkeys,pcrc_32_tab,c), t^(c))
 
 #ifdef INCLUDECRYPTINGCODE_IFCRYPTALLOWED
 

--- a/Common/ThirdParty/DDMinizip/other/ioapi.c
+++ b/Common/ThirdParty/DDMinizip/other/ioapi.c
@@ -30,43 +30,35 @@
 #endif
 
 voidpf ZCALLBACK fopen_file_func OF((
-   voidpf opaque,
    const char* filename,
    int mode));
 
 uLong ZCALLBACK fread_file_func OF((
-   voidpf opaque,
    voidpf stream,
    void* buf,
    uLong size));
 
 uLong ZCALLBACK fwrite_file_func OF((
-   voidpf opaque,
    voidpf stream,
    const void* buf,
    uLong size));
 
 long ZCALLBACK ftell_file_func OF((
-   voidpf opaque,
    voidpf stream));
 
 long ZCALLBACK fseek_file_func OF((
-   voidpf opaque,
    voidpf stream,
    uLong offset,
    int origin));
 
 int ZCALLBACK fclose_file_func OF((
-   voidpf opaque,
    voidpf stream));
 
 int ZCALLBACK ferror_file_func OF((
-   voidpf opaque,
    voidpf stream));
 
 
-voidpf ZCALLBACK fopen_file_func (opaque, filename, mode)
-   voidpf opaque;
+voidpf ZCALLBACK fopen_file_func (filename, mode)
    const char* filename;
    int mode;
 {
@@ -87,8 +79,7 @@ voidpf ZCALLBACK fopen_file_func (opaque, filename, mode)
 }
 
 
-uLong ZCALLBACK fread_file_func (opaque, stream, buf, size)
-   voidpf opaque;
+uLong ZCALLBACK fread_file_func (stream, buf, size)
    voidpf stream;
    void* buf;
    uLong size;
@@ -99,8 +90,7 @@ uLong ZCALLBACK fread_file_func (opaque, stream, buf, size)
 }
 
 
-uLong ZCALLBACK fwrite_file_func (opaque, stream, buf, size)
-   voidpf opaque;
+uLong ZCALLBACK fwrite_file_func (stream, buf, size)
    voidpf stream;
    const void* buf;
    uLong size;
@@ -110,8 +100,7 @@ uLong ZCALLBACK fwrite_file_func (opaque, stream, buf, size)
     return ret;
 }
 
-long ZCALLBACK ftell_file_func (opaque, stream)
-   voidpf opaque;
+long ZCALLBACK ftell_file_func (stream)
    voidpf stream;
 {
     long ret;
@@ -119,8 +108,7 @@ long ZCALLBACK ftell_file_func (opaque, stream)
     return ret;
 }
 
-long ZCALLBACK fseek_file_func (opaque, stream, offset, origin)
-   voidpf opaque;
+long ZCALLBACK fseek_file_func (stream, offset, origin)
    voidpf stream;
    uLong offset;
    int origin;
@@ -145,8 +133,7 @@ long ZCALLBACK fseek_file_func (opaque, stream, offset, origin)
     return ret;
 }
 
-int ZCALLBACK fclose_file_func (opaque, stream)
-   voidpf opaque;
+int ZCALLBACK fclose_file_func (stream)
    voidpf stream;
 {
     int ret;
@@ -154,8 +141,7 @@ int ZCALLBACK fclose_file_func (opaque, stream)
     return ret;
 }
 
-int ZCALLBACK ferror_file_func (opaque, stream)
-   voidpf opaque;
+int ZCALLBACK ferror_file_func (stream)
    voidpf stream;
 {
     int ret;

--- a/Common/ThirdParty/DDMinizip/other/ioapi.h
+++ b/Common/ThirdParty/DDMinizip/other/ioapi.h
@@ -35,13 +35,13 @@
 extern "C" {
 #endif
 
-typedef voidpf (ZCALLBACK *open_file_func) OF((voidpf opaque, const char* filename, int mode));
-typedef uLong  (ZCALLBACK *read_file_func) OF((voidpf opaque, voidpf stream, void* buf, uLong size));
-typedef uLong  (ZCALLBACK *write_file_func) OF((voidpf opaque, voidpf stream, const void* buf, uLong size));
-typedef long   (ZCALLBACK *tell_file_func) OF((voidpf opaque, voidpf stream));
-typedef long   (ZCALLBACK *seek_file_func) OF((voidpf opaque, voidpf stream, uLong offset, int origin));
-typedef int    (ZCALLBACK *close_file_func) OF((voidpf opaque, voidpf stream));
-typedef int    (ZCALLBACK *testerror_file_func) OF((voidpf opaque, voidpf stream));
+typedef voidpf (ZCALLBACK *open_file_func) OF((const char* filename, int mode));
+typedef uLong  (ZCALLBACK *read_file_func) OF((voidpf stream, void* buf, uLong size));
+typedef uLong  (ZCALLBACK *write_file_func) OF((voidpf stream, const void* buf, uLong size));
+typedef long   (ZCALLBACK *tell_file_func) OF((voidpf stream));
+typedef long   (ZCALLBACK *seek_file_func) OF((voidpf stream, uLong offset, int origin));
+typedef int    (ZCALLBACK *close_file_func) OF((voidpf stream));
+typedef int    (ZCALLBACK *testerror_file_func) OF((voidpf stream));
 
 typedef struct zlib_filefunc_def_s
 {
@@ -59,12 +59,12 @@ typedef struct zlib_filefunc_def_s
 
 void fill_fopen_filefunc OF((zlib_filefunc_def* pzlib_filefunc_def));
 
-#define ZREAD(filefunc,filestream,buf,size) ((*((filefunc).zread_file))((filefunc).opaque,filestream,buf,size))
-#define ZWRITE(filefunc,filestream,buf,size) ((*((filefunc).zwrite_file))((filefunc).opaque,filestream,buf,size))
-#define ZTELL(filefunc,filestream) ((*((filefunc).ztell_file))((filefunc).opaque,filestream))
-#define ZSEEK(filefunc,filestream,pos,mode) ((*((filefunc).zseek_file))((filefunc).opaque,filestream,pos,mode))
-#define ZCLOSE(filefunc,filestream) ((*((filefunc).zclose_file))((filefunc).opaque,filestream))
-#define ZERROR(filefunc,filestream) ((*((filefunc).zerror_file))((filefunc).opaque,filestream))
+#define ZREAD(filefunc,filestream,buf,size) ((*((filefunc).zread_file))(filestream,buf,size))
+#define ZWRITE(filefunc,filestream,buf,size) ((*((filefunc).zwrite_file))(filestream,buf,size))
+#define ZTELL(filefunc,filestream) ((*((filefunc).ztell_file))(filestream))
+#define ZSEEK(filefunc,filestream,pos,mode) ((*((filefunc).zseek_file))(filestream,pos,mode))
+#define ZCLOSE(filefunc,filestream) ((*((filefunc).zclose_file))(filestream))
+#define ZERROR(filefunc,filestream) ((*((filefunc).zerror_file))(filestream))
 
 
 #ifdef __cplusplus

--- a/Common/ThirdParty/DDMinizip/other/unzip.c
+++ b/Common/ThirdParty/DDMinizip/other/unzip.c
@@ -420,8 +420,7 @@ extern unzFile ZEXPORT unzOpen2 (path, pzlib_filefunc_def)
     else
         us.z_filefunc = *pzlib_filefunc_def;
 
-    us.filestream= (*(us.z_filefunc.zopen_file))(us.z_filefunc.opaque,
-                                                 path,
+    us.filestream= (*(us.z_filefunc.zopen_file))(path,
                                                  ZLIB_FILEFUNC_MODE_READ |
                                                  ZLIB_FILEFUNC_MODE_EXISTING);
     if (us.filestream==NULL)

--- a/Common/ThirdParty/DDMinizip/other/zip.c
+++ b/Common/ThirdParty/DDMinizip/other/zip.c
@@ -189,14 +189,6 @@ local void init_linkedlist(ll)
     ll->first_block = ll->last_block = NULL;
 }
 
-local void free_linkedlist(ll)
-    linkedlist_data* ll;
-{
-    free_datablock(ll->first_block);
-    ll->first_block = ll->last_block = NULL;
-}
-
-
 local int add_data_in_datablock(ll,buf,len)
     linkedlist_data* ll;
     const void* buf;
@@ -315,9 +307,8 @@ local void ziplocal_putValue_inmemory (dest, x, nbByte)
 /****************************************************************************/
 
 
-local uLong ziplocal_TmzDateToDosDate(ptm,dosDate)
+local uLong ziplocal_TmzDateToDosDate(ptm)
     const tm_zip* ptm;
-    uLong dosDate;
 {
     uLong year = (uLong)ptm->tm_year;
     if (year>1980)
@@ -513,8 +504,7 @@ extern zipFile ZEXPORT zipOpen2 (pathname, append, globalcomment, pzlib_filefunc
         ziinit.z_filefunc = *pzlib_filefunc_def;
 
     ziinit.filestream = (*(ziinit.z_filefunc.zopen_file))
-                 (ziinit.z_filefunc.opaque,
-                  pathname,
+                 (pathname,
                   (append == APPEND_STATUS_CREATE) ?
                   (ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_WRITE | ZLIB_FILEFUNC_MODE_CREATE) :
                     (ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_WRITE | ZLIB_FILEFUNC_MODE_EXISTING));
@@ -753,7 +743,7 @@ extern int ZEXPORT zipOpenNewFileInZip3 (file, filename, zipfi,
     {
         if (zipfi->dosDate != 0)
             zi->ci.dosDate = zipfi->dosDate;
-        else zi->ci.dosDate = ziplocal_TmzDateToDosDate(&zipfi->tmz_date,zipfi->dosDate);
+        else zi->ci.dosDate = ziplocal_TmzDateToDosDate(&zipfi->tmz_date);
     }
 
     zi->ci.flag = 0;

--- a/Common/ThirdParty/DDMinizip/src/DDZipReader.m
+++ b/Common/ThirdParty/DDMinizip/src/DDZipReader.m
@@ -115,7 +115,7 @@
 			[fman createDirectoryAtPath:[fullPath stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:nil error:nil];
         
         //test
-        DDZippedFileInfo *info = [[DDZippedFileInfo alloc] initWithName:strPath andNativeInfo:fileInfo];
+        DDZippedFileInfo *info = [[[DDZippedFileInfo alloc] initWithName:strPath andNativeInfo:fileInfo] autorelease];
         NSLog(@"%@", info.date);
         
               //ask delegate for overwrite
@@ -205,7 +205,7 @@
 -(BOOL) shouldOverwrite:(NSString*)file withName:(NSString*)name andFileInfo:(unz_file_info)fileInfo
 {
 	if( _delegate && [_delegate respondsToSelector:@selector(zipArchive:shouldOverwriteFile:withZippedFile:)] ) {
-        DDZippedFileInfo *info = [[DDZippedFileInfo alloc] initWithName:name andNativeInfo:fileInfo];    
+        DDZippedFileInfo *info = [[[DDZippedFileInfo alloc] initWithName:name andNativeInfo:fileInfo] autorelease];
 		return [_delegate zipArchive:self shouldOverwriteFile:file withZippedFile:info];
     }
 	return NO;

--- a/Common/ThirdParty/DDMinizip/src/DDZippedFileInfo.m
+++ b/Common/ThirdParty/DDMinizip/src/DDZippedFileInfo.m
@@ -54,23 +54,21 @@
 
 +(NSDate*) dateWithMUDate:(tm_unz)mu_date
 {
-	NSDateComponents *comps = [[NSDateComponents alloc] init];
+	NSDateComponents *comps = [[[NSDateComponents alloc] init] autorelease];
     [comps setSecond:mu_date.tm_sec];
     [comps setMinute:mu_date.tm_min];
     [comps setHour:mu_date.tm_hour];
 	[comps setDay:mu_date.tm_mday];
 	[comps setMonth:mu_date.tm_mon];
     [comps setYear:mu_date.tm_year];
-	NSCalendar *gregorian = [[NSCalendar alloc]
-							 initWithCalendarIdentifier:NSGregorianCalendar];
+	NSCalendar *gregorian = [NSCalendar calendarWithIdentifier:NSGregorianCalendar];
 	NSDate *date = [gregorian dateFromComponents:comps];
 	return date;
 }
 
 +(tm_zip) mzDateWithDate:(NSDate*)date
 {
-	NSCalendar *gregorian = [[NSCalendar alloc]
-							 initWithCalendarIdentifier:NSGregorianCalendar];
+	NSCalendar *gregorian = [NSCalendar calendarWithIdentifier:NSGregorianCalendar];
 	NSDateComponents *comps = [gregorian components:NSSecondCalendarUnit | NSMinuteCalendarUnit | NSHourCalendarUnit | NSDayCalendarUnit | NSMonthCalendarUnit | NSYearCalendarUnit fromDate:date];
     tm_zip mu_date;
     mu_date.tm_sec = (uInt)comps.second;
@@ -87,16 +85,13 @@
 
 +(NSDate*) dateWithTimeIntervalSince1980:(NSTimeInterval)interval
 {
-	NSDateComponents *comps = [[NSDateComponents alloc] init];
+	NSDateComponents *comps = [[[NSDateComponents alloc] init] autorelease];
 	[comps setDay:1];
 	[comps setMonth:1];
 	[comps setYear:1980];
-	NSCalendar *gregorian = [[NSCalendar alloc]
-							 initWithCalendarIdentifier:NSGregorianCalendar];
+	NSCalendar *gregorian = [NSCalendar calendarWithIdentifier:NSGregorianCalendar];
 	NSDate *date = [gregorian dateFromComponents:comps];
 	
-    //	[comps release];
-    //	[gregorian release];
 	return [date dateByAddingTimeInterval:interval];
 }
 

--- a/Common/ThirdParty/DDUtils/DDEmbeddedDataReader.m
+++ b/Common/ThirdParty/DDUtils/DDEmbeddedDataReader.m
@@ -150,9 +150,9 @@ NSData *_BVMachOSectionFromMachOHeader(char *addr, long bytes_left, char *segnam
 
 #pragma mark - Definition of private functions for error reporting
 NSError *_BVPOSIXError(NSURL *url) {
-    NSError *underlyingError = [[NSError alloc] initWithDomain:NSPOSIXErrorDomain
-                                                          code:errno
-                                                      userInfo:nil];
+    NSError *underlyingError = [NSError errorWithDomain:NSPOSIXErrorDomain
+                                                   code:errno
+                                               userInfo:nil];
     NSString *errorDescription = [NSString stringWithFormat:@"File %@ could not be opened. %s.",
                                   [url path], strerror(errno)];
     NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:

--- a/Common/ThirdParty/DDUtils/DDXcodeProjectFile.m
+++ b/Common/ThirdParty/DDUtils/DDXcodeProjectFile.m
@@ -70,7 +70,7 @@
 }
 
 + (id)xcodeProjectFileWithPath:(NSString*)path error:(NSError**)pError {
-    id file = [[[self class] alloc] initWithPath:path];
+    id file = [[[[self class] alloc] initWithPath:path] autorelease];
     if(file) {
         if([file parse:pError]) {
             return file;
@@ -80,7 +80,7 @@
 }
 
 + (id)xcodeProjectFileWithDictionary:(NSDictionary*)dict error:(NSError**)pError {
-    id file = [[[self class] alloc] initWithDictionary:dict];
+    id file = [[[[self class] alloc] initWithDictionary:dict] autorelease];
     if(file) {
         if([file parse:pError]) {
             return file;
@@ -224,7 +224,7 @@
 
 - (NSError*)parsePBXFileReference:(NSDictionary*)dict {
     if(!dict[@"lastKnownFileType"] && dict[@"explicitFileType"]) {
-        NSMutableDictionary *mdict = dict.mutableCopy;
+        NSMutableDictionary *mdict = [[dict mutableCopy] autorelease];
         mdict[@"lastKnownFileType"] = dict[@"explicitFileType"];
         dict = mdict;
     }

--- a/Parsing/GBTokenizer.m
+++ b/Parsing/GBTokenizer.m
@@ -216,8 +216,8 @@
 	// This method checks if current token is a comment and consumes all comments until non-comment token is detected or EOF reached. The result of the method is that current index is positioned on the first non-comment token. If current token is not comment, the method doesn't do anything, but simply returns NO to indicate it didn't find a comment and therefore it didn't move current token. This is also where we do initial comments handling such as removing starting and ending chars etc.
 	if ([self eof]) return NO;
 
-	PKToken *startingPreviousToken = nil;
-	PKToken *startingLastToken = nil;
+	//PKToken *startingPreviousToken = nil;
+	//PKToken *startingLastToken = nil;
 	NSUInteger previousSingleLineEndOffset = NSNotFound;
 	NSInteger previousSingleLineIndentation = -1;
 	while (![self eof] && [[self currentToken] isComment]) {
@@ -238,12 +238,12 @@
 				[self.lastCommentBuilder appendString:@"\n"];
 			} else {
 				[self.previousCommentBuilder setString:self.lastCommentBuilder];
-				startingPreviousToken = startingLastToken;
+				//startingPreviousToken = startingLastToken;
 				[self.lastCommentBuilder setString:@""];
 				self.isPreviousCommentMultiline = self.isLastCommentMultiline;
 				self.previousCommentToken = self.lastCommentToken;
 				self.isLastCommentMultiline = NO;
-				startingLastToken = token;
+				//startingLastToken = token;
 				self.lastCommentToken = token;
 			}
 			previousSingleLineEndOffset = [token offset] + [[token stringValue] length];
@@ -255,12 +255,12 @@
 			NSArray *multiLiners = [[token stringValue] componentsMatchedByRegex:self.multiLineCommentRegex capture:1];
 			value = [multiLiners lastObject];
 			[self.previousCommentBuilder setString:self.lastCommentBuilder];
-			startingPreviousToken = startingLastToken;
+			//startingPreviousToken = startingLastToken;
 			[self.lastCommentBuilder setString:@""];
 			self.isPreviousCommentMultiline = self.isLastCommentMultiline;
 			self.previousCommentToken = self.lastCommentToken;
 			self.isLastCommentMultiline = YES;
-			startingLastToken = token;
+			//startingLastToken = token;
 			self.lastCommentToken = token;
 			}
 
@@ -275,8 +275,8 @@
 	if (self.settings && [self.lastCommentBuilder isMatchedByRegex:self.settings.commentComponents.methodGroupRegex]) {
 		self.previousCommentBuilder = [self.lastCommentBuilder mutableCopy];
 		[self.lastCommentBuilder setString:@""];
-		startingPreviousToken = startingLastToken;
-		startingLastToken = nil;
+		//startingPreviousToken = startingLastToken;
+		//startingLastToken = nil;
 		self.previousCommentToken = self.lastCommentToken;
 		self.lastCommentToken = nil;
 	}


### PR DESCRIPTION
Removing Xcode warnings.

On a note, you might also want to update minizip with the version available at https://github.com/Coeur/ZipArchive/tree/master/minizip as it includes fixes from minizip versions 1.01h and 1.1.