### PR TITLE
Command line option to overwrite default documentation section title on index page

### DIFF
--- a/Application/GBAppledocApplication.m
+++ b/Application/GBAppledocApplication.m
@@ -43,6 +43,7 @@ static char *kGBArgPublishDocSet = "publish-docset";
 static char *kGBArgHTMLAnchorFormat = "html-anchors";
 static char *kGBArgKeepIntermediateFiles = "keep-intermediate-files";
 static char *kGBArgExitCodeThreshold = "exit-threshold";
+static char *kGBArgDocsSectionTitle = "docs-section-title";
 
 static char *kGBArgRepeatFirstParagraph = "repeat-first-par";
 static char *kGBArgPreprocessHeaderDoc = "preprocess-headerdoc";
@@ -301,6 +302,7 @@ static char *kGBArgHelp = "help";
 		{ kGBArgPrefixMergedCategoriesSectionsWithCategoryName,				0,		DDGetoptNoArgument },
     	{ kGBArgUseCodeOrder,                                               0,		DDGetoptNoArgument },
 		{ kGBArgExitCodeThreshold,											0,		DDGetoptRequiredArgument },
+		{ kGBArgDocsSectionTitle,                                           0,		DDGetoptRequiredArgument },
 		{ GBNoArg(kGBArgKeepIntermediateFiles),								0,		DDGetoptNoArgument },
 		{ GBNoArg(kGBArgKeepUndocumentedObjects),							0,		DDGetoptNoArgument },
 		{ GBNoArg(kGBArgKeepUndocumentedMembers),							0,		DDGetoptNoArgument },
@@ -817,6 +819,7 @@ static char *kGBArgHelp = "help";
 - (void)setNoExplicitCrossref:(BOOL)value { [self setExplicitCrossref:!value]; }
 
 - (void)setExitThreshold:(int)value { self.settings.exitCodeThreshold = value; }
+- (void)setDocsSectionTitle:(NSString *)value { self.settings.docsSectionTitle = value; }
 - (void)setKeepIntermediateFiles:(BOOL)value { self.settings.keepIntermediateFiles = value;}
 - (void)setKeepUndocumentedObjects:(BOOL)value { self.settings.keepUndocumentedObjects = value; }
 - (void)setKeepUndocumentedMembers:(BOOL)value { self.settings.keepUndocumentedMembers = value; }
@@ -972,6 +975,7 @@ static char *kGBArgHelp = "help";
     ddprintf(@"--%s = %@\n", kGBArgCrossRefFormat, self.settings.commentComponents.crossReferenceMarkersTemplate);
     ddprintf(@"--%s = %@\n", kGBArgUseCodeOrder, self.settings.useCodeOrder);
     ddprintf(@"--%s = %ld\n", kGBArgExitCodeThreshold, self.settings.exitCodeThreshold);
+    ddprintf(@"--%s = %@\n", kGBArgDocsSectionTitle, self.settings.docsSectionTitle);
     ddprintf(@"\n");
     
     ddprintf(@"--%s = %@\n", kGBArgWarnOnMissingOutputPath, PRINT_BOOL(self.settings.warnOnMissingOutputPathArgument));
@@ -1043,7 +1047,8 @@ static char *kGBArgHelp = "help";
     PRINT_USAGE(@"   ", kGBArgUseCodeOrder, @"", @"[b] Order sections by the order specified in the input files");
     PRINT_USAGE(@"   ", kGBArgCrossRefFormat, @"<string>", @"Cross reference template regex");
     PRINT_USAGE(@"   ", kGBArgExitCodeThreshold, @"<number>", @"Exit code threshold below which 0 is returned");
-	ddprintf(@"\n");
+	PRINT_USAGE(@"   ", kGBArgDocsSectionTitle, @"<string>", @"Title of the documentation section (defaults to \"Programming Guides\"");
+    ddprintf(@"\n");
 	ddprintf(@"WARNINGS\n");
 	PRINT_USAGE(@"   ", kGBArgWarnOnMissingOutputPath, @"", @"[b] Warn if output path is not given");
 	PRINT_USAGE(@"   ", kGBArgWarnOnMissingCompanyIdentifier, @"", @"[b] Warn if company ID is not given");

--- a/Application/GBApplicationSettingsProvider.h
+++ b/Application/GBApplicationSettingsProvider.h
@@ -421,6 +421,10 @@ NSString *NSStringFromGBPublishedFeedFormats(GBPublishedFeedFormats format);
  */
 @property (assign) int exitCodeThreshold;
 
+/** Title of the documentation section */
+@property (copy) NSString *docsSectionTitle;
+
+
 ///---------------------------------------------------------------------------------------
 /// @name Warnings handling
 ///---------------------------------------------------------------------------------------

--- a/Application/GBApplicationSettingsProvider.m
+++ b/Application/GBApplicationSettingsProvider.m
@@ -144,6 +144,7 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBApplicationSettingsProvider, sharedApplicationS
 		self.findUndocumentedMembersDocumentation = YES;
 		self.treatDocSetIndexingErrorsAsFatals = NO;
 		self.exitCodeThreshold = 0;
+        self.docsSectionTitle = nil;
 		
 		self.mergeCategoriesToClasses = YES;
 		self.mergeCategoryCommentToClass = YES;
@@ -702,6 +703,7 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBApplicationSettingsProvider, sharedApplicationS
 @synthesize cleanupOutputPathBeforeRunning;
 @synthesize treatDocSetIndexingErrorsAsFatals;
 @synthesize exitCodeThreshold;
+@synthesize docsSectionTitle;
 
 @synthesize warnOnMissingOutputPathArgument;
 @synthesize warnOnMissingCompanyIdentifier;

--- a/Generating/GBHTMLTemplateVariablesProvider.m
+++ b/Generating/GBHTMLTemplateVariablesProvider.m
@@ -69,6 +69,7 @@
 
 - (NSString *)pageTitleForIndex;
 - (NSString *)pageTitleForHierarchy;
+- (NSString *)docsSectionTitleForIndex;
 - (NSArray *)documentsForIndex;
 - (NSArray *)classesForIndex;
 - (NSArray *)categoriesForIndex;
@@ -206,6 +207,7 @@
 	self.store = aStore;
 	NSMutableDictionary *page = [NSMutableDictionary dictionary];
 	[page setObject:[self pageTitleForIndex] forKey:@"title"];
+    [page setObject:[self docsSectionTitleForIndex] forKey:@"docsTitle"];
 	[self addFooterVarsToDictionary:page];
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
 	[result setObject:page forKey:@"page"];
@@ -540,6 +542,15 @@
 - (NSString *)pageTitleForHierarchy {
 	NSString *template = [self.settings.stringTemplates.hierarchyPage objectForKey:@"titleTemplate"];
 	return [NSString stringWithFormat:template, self.settings.projectName];
+}
+
+- (NSString *)docsSectionTitleForIndex {
+    if ([self.settings.docsSectionTitle length] > 0)
+    {
+        return self.settings.docsSectionTitle;
+    }
+    
+    return [self.settings.stringTemplates.indexPage objectForKey:@"docsTitle"];
 }
 
 - (NSArray*)documentsForIndex{

--- a/Templates/html/index-template.html
+++ b/Templates/html/index-template.html
@@ -53,7 +53,7 @@
 					<div class="index-container">
 						{{#hasDocs}}
 						<div class="index-column">
-							<h2 class="index-title">{{strings.indexPage.docsTitle}}</h2>
+							<h2 class="index-title">{{page.docsTitle}}</h2>
 							<ul>
 								{{#docs}}
 								<li><a href="{{href}}">{{title}}</a></li>


### PR DESCRIPTION
Hi,

by the use of the new command line option "docs-section-title" the default documentation section title "Programming Guides" can be changed to another string (e.g. Overview). This feature is requested by some users (https://groups.google.com/forum/#!msg/appledoc/WY8A7S-1EBQ/PYUSqCpu6J4J).