### PR TITLE
Ignore cross references inside markdown fenced code blocks

### DIFF
--- a/Application/GBApplicationStringsProvider.m
+++ b/Application/GBApplicationStringsProvider.m
@@ -152,7 +152,7 @@
 		result = [[NSMutableDictionary alloc] init];
 		[result setObject:@"appledoc" forKey:@"tool"];
 		[result setObject:@"2.2.1" forKey:@"version"];
-		[result setObject:@"1333" forKey:@"build"];
+		[result setObject:@"1334" forKey:@"build"];
 		[result setObject:@"http://appledoc.gentlebytes.com" forKey:@"homepage"];
 	}
 	return result;


### PR DESCRIPTION
This change makes `GBCommentsProcessor` to ignore cross references inside *markdown fenced code blocks* (\`\`\``code block`\`\`\`, see [GitHub Flavored Markdown documentation](https://help.github.com/articles/github-flavored-markdown/) for details).

This allows to workaround longstanding issues like #253 or #348 by making the sample code whose warnings you want to avoid a fenced block.

Particularly, this will allow to suppress warnings when generating docs for Apple's [ResearchKit](https://github.com/ResearchKit/ResearchKit).

I don't think this causes any unintended side effect. All the unit tests continue to pass after this change.