### PR TITLE
Fix regex for Markdown reference link.

### DIFF
--- a/Application/GBCommentComponentsProvider.m
+++ b/Application/GBCommentComponentsProvider.m
@@ -101,7 +101,7 @@
 }
 
 - (NSString *)markdownReferenceLinkRegex {
-	GBRETURN_ON_DEMAND(@"(?s:\\[([^]]+)\\]:\\s*([^\\s]+)(?:\\s*\"([^\"]+)\")?\\s*$)");
+    GBRETURN_ON_DEMAND(@"(?s:\\[([^]]+)\\]:\\s*([^\\s]+)(?:\\s*\"([^\"]+)\")?)");
 }
 
 #pragma mark Cross references detection


### PR DESCRIPTION
Somehow `\\s*$` cause this regex stop to work. It can be reproduce by the following case:

    You can use [Title][ref] to ....
    
    [ref]: link

Expect:
`<p>You can use <a href="link">Title</a> to ....`

Result:
`<p>You can use <a href="[ref](link)">Title</a> to ....`