### PR TITLE
Ignore source-code-blocks while processing comments.

### DIFF
--- a/Processing/GBCommentsProcessor+CodeBlockProcessing.h
+++ b/Processing/GBCommentsProcessor+CodeBlockProcessing.h
@@ -1,0 +1,38 @@
+//
+//  GBCommentsProcessor+CodeBlockProcessing.h
+//  appledoc
+//
+//  Created by Jody Hagins on 9/6/15.
+//  Copyright (c) 2015 Gentle Bytes. All rights reserved.
+//
+
+#import "GBCommentsProcessor.h"
+
+@interface GBCommentsProcessor (CodeBlockProcessing)
+
+/**
+ Get a collection of components contained in the @a string
+
+ Specifically, this method searches for source-code-block components and reference-link components.
+
+ No two components will overlap, and the resulting array will be sorted, relative to the range location
+
+ @param string the text to search
+
+ @return a sorted array of dictionaries, where each dictionary represents either a reference-link component or a source-code-block component.
+
+     - If the component is a reference-link component, the dictionary will contain these keys
+         - "link" (NSString) will contain all the text matching as a link reference - of the form [foo](bar)
+         - "range" (NSRange wrapped in NSValue) will be the range for the link text, relative to the original @a string
+
+     - If the component is a source-code-link component, the dictionary will contain these keys
+         - "begin" (NSString) the token marking the beginning of the code block
+         - "end" (NSString) the token marking the end of the code block
+         - "prefix" (NSString) all the text before the start of the code block, including the line containing the begining marker
+         - "postfix" (NSString) all the text after the code block, including the line containing the ending marker
+         - "code" (NSString) all the text between the begining and ending markers
+         - "range" (NSRange wrapped in NSValue) the range for the code text, relative to the original @a string
+ */
+- (NSArray*)codeAndLinkComponentsInString:(NSString*)string;
+
+@end

--- a/Processing/GBCommentsProcessor+CodeBlockProcessing.m
+++ b/Processing/GBCommentsProcessor+CodeBlockProcessing.m
@@ -1,0 +1,138 @@
+//
+//  GBCommentsProcessor+CodeBlockProcessing.m
+//  appledoc
+//
+//  Created by Jody Hagins on 9/6/15.
+//  Copyright (c) 2015 Gentle Bytes. All rights reserved.
+//
+
+#import "GBCommentsProcessor+CodeBlockProcessing.h"
+#import "RegexKitLite.h"
+
+@implementation GBCommentsProcessor (CodeBlockProcessing)
+
+/**
+ Fetch any source-code-block components from @a string
+
+ This method will search @a string for any recognized source-code-blocks.  A block will be any text between doxygen style @code/@endcode markers or any text between markdown markers ``` or ~~~.
+
+ This is not a top-level marker, and will be parsed from within another comment block.
+
+ The beginning and ending markers must each be on a new line, with nothing else but whitespace on that line.
+
+ @param string the text in which to search for source-code-blocks
+
+ @return an array of dictionaries, where each dictionary contains six key-value pairs.
+
+ - begin the token marking the beginning of the code block
+ - end the token marking the end of the code block
+ - prefix all the text before the start of the code block, including the line containing the begining marker
+ - postfix all the text after the code block, including the line containing the ending marker
+ - code all the text between the begining and ending markers
+ - range the range for the code text, relative to the original @a string
+ */
+- (NSArray*)codeComponentsInString:(NSString*)string {
+    NSRange searchRange = NSMakeRange(0, [string length]);
+    NSMutableArray *result = [[NSMutableArray alloc] init];
+
+    NSString *pattern = @"\\r?\\n(([ \\t]*(~~~|```|@code)[ \\t]*)\\r?\\n[\\s\\S]*?\\r?\\n([ \\t]*(\\3|@endcode)[ \\t]*)\\r?\\n)";
+    NSArray *components = [string arrayOfDictionariesByMatchingRegex:pattern withKeysAndCaptures:@"code", 1, @"prefix", 2, @"begin", 3, @"postfix", 4, @"end", 5, nil];
+    for (NSDictionary *d in components) {
+        NSString *begin = [d objectForKey:@"begin"];
+        NSString *end = [d objectForKey:@"end"];
+        if (([begin isEqualToString:@"@code"] && [end isEqualToString:@"@endcode"]) || [begin isEqualToString:end]) {
+            NSString *body = [d objectForKey:@"code"];
+            NSRange range = [string rangeOfString:body options:0 range:searchRange];
+            NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithDictionary:d];
+            [dict setObject:[NSValue valueWithRange:range] forKey:@"range"];
+            [result addObject:[dict copy]];
+        }
+    }
+    return [result copy];
+}
+
+/**
+ Do the link component and the code component overlap?
+
+ @param link a reference-link component
+ @param a source-code-block component
+
+ @return YES if the link component shares any text in common with the source-code-block component.
+ */
+- (BOOL)linkComponent:(NSDictionary*)link overlapsCodeComponent:(NSDictionary*)code {
+    NSRange linkRange = [[link objectForKey:@"range"] rangeValue];
+    NSUInteger linkBegin = linkRange.location;
+    NSUInteger linkEnd = linkRange.location + linkRange.length;
+
+    NSRange codeRange = [[code objectForKey:@"range"] rangeValue];
+    NSUInteger codeBegin = codeRange.location;
+    NSUInteger codeEnd = codeRange.location + codeRange.length;
+    return (linkBegin >= codeBegin && linkBegin < codeEnd) || (linkEnd > codeBegin && linkEnd <= codeEnd);
+}
+
+/**
+ Fetch any reference link components from @a string
+
+ This method will search @a string for any recognized reference links - something roughly of the form [foo](bar).
+
+ @param string the text in which to search for reference links
+ @param codeComponents the source-code-block component that have already been found for this same @a string.  Any link found within the known soucre-code blocks will be ignored and not included in the resulting array of components.
+
+ @return an array of dictionaries, where each dictionary contains two key-value pairs.
+
+ - "link" all the text matching as a link reference
+ - "range" the range for the link text, relative to the original @a string
+ */
+- (NSArray*)linkComponentsInString:(NSString*)string withCodeComponents:(NSArray*)codeComponents {
+    NSRange searchRange = NSMakeRange(0, [string length]);
+    NSMutableArray *result = [[NSMutableArray alloc] init];
+
+    NSString *pattern = @"(\\[.+?\\]\\(.+?\\))";
+    NSArray *components = [string arrayOfDictionariesByMatchingRegex:pattern withKeysAndCaptures:@"link", 1, nil];
+    for (NSDictionary *d in components) {
+        NSString *body = [d objectForKey:@"link"];
+        NSRange range = [string rangeOfString:body options:0 range:searchRange];
+        NSDictionary *link = @{@"link":body, @"range":[NSValue valueWithRange:range]};
+        BOOL overlaps = NO;
+        for (NSDictionary *code in codeComponents) {
+            if ([self linkComponent:link overlapsCodeComponent:code]) {
+                overlaps = YES;
+                break;
+            }
+        }
+        if (!overlaps) {
+            [result addObject:link];
+        }
+    }
+    return result;
+}
+
+/**
+ Merge the two sets of components so that they are in sorted order, relative to their range location
+
+ @param codeComponents the array of soucrec-code-block components
+ @param linkComponents the array of reference-link components
+
+ @return An array containing both code and link components, sorted by range location
+ */
+- (NSArray*)mergeCodeComponents:(NSArray*)codeComponents linkComponents:(NSArray*)linkComponents {
+    return [[codeComponents arrayByAddingObjectsFromArray:linkComponents] sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
+        NSRange range1 = [[obj1 objectForKey:@"range"] rangeValue];
+        NSRange range2 = [[obj2 objectForKey:@"range"] rangeValue];
+        return (range1.location < range2.location
+                ? NSOrderedAscending
+                : (range1.location == range2.location
+                   ? NSOrderedSame
+                   : NSOrderedDescending));
+    }];
+}
+
+
+// See header file for documenetation
+- (NSArray*)codeAndLinkComponentsInString:(NSString*)string {
+    NSArray *codeComponents = [self codeComponentsInString:string];
+    NSArray *linkComponents = [self linkComponentsInString:string withCodeComponents:codeComponents];
+    return [self mergeCodeComponents:codeComponents linkComponents:linkComponents];
+}
+
+@end

--- a/Processing/GBCommentsProcessor.h
+++ b/Processing/GBCommentsProcessor.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class GBComment;
+@class GBComment, GBModelBase;
 
 /** Implements comments processing.
  

--- a/Testing/GBCommentsProcessor-PreprocessingTesting.m
+++ b/Testing/GBCommentsProcessor-PreprocessingTesting.m
@@ -155,6 +155,17 @@
     assertThat(result, is(@"\n```\n[self doSomething];\n```\n"));
 }
 
+- (void)testStringByPreprocessingString_shouldConvertMultipleCodeBlocksToMarkdownBackticks {
+    // setup
+    GBCommentsProcessor *processor = [self defaultProcessor];
+    NSString *raw = @"\n  @code  \n[self doSomething];\n  @endcode  \n\n  @code  \n[self doSomething];\n  @endcode  \n";
+    NSString *expected = @"\n```\n[self doSomething];\n```\n\n```\n[self doSomething];\n```\n";
+    // execute
+    NSString *result = [processor stringByPreprocessingString:raw withFlags:0];
+    // verify
+    assertThat(result, is(expected));
+}
+
 #pragma mark Class, category and protocol cross references detection
 
 - (void)testStringByConvertingCrossReferencesInString_shouldConvertClass {

--- a/Testing/GBCommentsProcessor-PreprocessingTesting.m
+++ b/Testing/GBCommentsProcessor-PreprocessingTesting.m
@@ -128,6 +128,33 @@
 	assertThat(result, is(@"[test_test](http://www.example.com/test_test.html)"));
 }
 
+- (void)testStringByPreprocessingString_shouldConvertCodeBlockToMarkdownBackticks {
+    // setup
+    GBCommentsProcessor *processor = [self defaultProcessor];
+    // execute
+    NSString *result = [processor stringByPreprocessingString:@"\n  @code  \n[self doSomething];\n  @endcode  \n" withFlags:0];
+    // verify
+    assertThat(result, is(@"\n```\n[self doSomething];\n```\n"));
+}
+
+- (void)testStringByPreprocessingString_shouldConvertTildeCodeBlockToMarkdownBackticks {
+    // setup
+    GBCommentsProcessor *processor = [self defaultProcessor];
+    // execute
+    NSString *result = [processor stringByPreprocessingString:@"\n  ~~~  \n[self doSomething];\n  ~~~  \n" withFlags:0];
+    // verify
+    assertThat(result, is(@"\n```\n[self doSomething];\n```\n"));
+}
+
+- (void)testStringByPreprocessingString_shouldConvertBacktickCodeBlockToMarkdownBackticks {
+    // setup
+    GBCommentsProcessor *processor = [self defaultProcessor];
+    // execute
+    NSString *result = [processor stringByPreprocessingString:@"\n  ```  \n[self doSomething];\n  ```  \n" withFlags:0];
+    // verify
+    assertThat(result, is(@"\n```\n[self doSomething];\n```\n"));
+}
+
 #pragma mark Class, category and protocol cross references detection
 
 - (void)testStringByConvertingCrossReferencesInString_shouldConvertClass {

--- a/appledoc.xcodeproj/project.pbxproj
+++ b/appledoc.xcodeproj/project.pbxproj
@@ -201,6 +201,8 @@
 		B8BBC0F7196DFAEB006F239D /* dd_getopt_long-fbsd.m in Sources */ = {isa = PBXBuildFile; fileRef = DA77C690196BEB2C0018A48F /* dd_getopt_long-fbsd.m */; };
 		B8F381D6197D5AAB002F8B92 /* libGRMustache7-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B8F381D5197D5AAB002F8B92 /* libGRMustache7-iOS.a */; };
 		B8F381D7197D5ABE002F8B92 /* libGRMustache7-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B8F381D5197D5AAB002F8B92 /* libGRMustache7-iOS.a */; };
+		C8005C981B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m in Sources */ = {isa = PBXBuildFile; fileRef = C8005C971B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m */; };
+		C8005C991B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m in Sources */ = {isa = PBXBuildFile; fileRef = C8005C971B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m */; };
 		D4B844EC17A121040012C1DC /* GBTypedefEnumData.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B844EB17A121030012C1DC /* GBTypedefEnumData.m */; };
 		D4B844EF17A122670012C1DC /* GBEnumConstantData.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B844EE17A122650012C1DC /* GBEnumConstantData.m */; };
 		D4B844F217A122A60012C1DC /* GBEnumConstantProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B844F117A122A50012C1DC /* GBEnumConstantProvider.m */; };
@@ -511,6 +513,8 @@
 		C5676812195840BD00E8E4C8 /* GBTypedefBlockArgument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GBTypedefBlockArgument.h; sourceTree = "<group>"; };
 		C5676813195840BD00E8E4C8 /* GBTypedefBlockArgument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GBTypedefBlockArgument.m; sourceTree = "<group>"; };
 		C5996C98195B0E55007E9AAC /* SynthesizeSingleton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SynthesizeSingleton.h; sourceTree = "<group>"; };
+		C8005C961B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "GBCommentsProcessor+CodeBlockProcessing.h"; path = "../../../appledoc/Processing/GBCommentsProcessor+CodeBlockProcessing.h"; sourceTree = "<group>"; };
+		C8005C971B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "GBCommentsProcessor+CodeBlockProcessing.m"; path = "../../../appledoc/Processing/GBCommentsProcessor+CodeBlockProcessing.m"; sourceTree = "<group>"; };
 		D45D15E117D883C700B7976A /* CommentsFormattingStyle.markdown */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CommentsFormattingStyle.markdown; sourceTree = "<group>"; };
 		D4B844EA17A121000012C1DC /* GBTypedefEnumData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GBTypedefEnumData.h; sourceTree = "<group>"; };
 		D4B844EB17A121030012C1DC /* GBTypedefEnumData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GBTypedefEnumData.m; sourceTree = "<group>"; };
@@ -877,6 +881,8 @@
 		73F70DF41227C23900D19EBA /* Processing */ = {
 			isa = PBXGroup;
 			children = (
+				C8005C961B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.h */,
+				C8005C971B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m */,
 				73F2CA72123E4161009B406B /* GBProcessor.h */,
 				73F2CA73123E4161009B406B /* GBProcessor.m */,
 				73F2CA70123E4161009B406B /* GBCommentsProcessor.h */,
@@ -1329,6 +1335,7 @@
 				73F2CA74123E4161009B406B /* GBCommentsProcessor.m in Sources */,
 				73F2CA75123E4161009B406B /* GBProcessor.m in Sources */,
 				7307B311124A1929007EC6B8 /* GBObjectiveCParser-SectionsParsingTesting.m in Sources */,
+				C8005C991B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m in Sources */,
 				7307B31A124A1C2E007EC6B8 /* GBMethodSectionData.m in Sources */,
 				736B2BF6124BCBB6009145B1 /* GBSourceInfo.m in Sources */,
 				739AD57F1255C3E600B642C3 /* GBApplicationStringsProvider.m in Sources */,
@@ -1420,6 +1427,7 @@
 				73AA9F731253BF4000074152 /* GBGenerator.m in Sources */,
 				DA77C691196BEB2C0018A48F /* dd_getopt_long-fbsd.m in Sources */,
 				739AD5801255C3E600B642C3 /* GBApplicationStringsProvider.m in Sources */,
+				C8005C981B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m in Sources */,
 				739AD6301255D8CB00B642C3 /* GBHTMLTemplateVariablesProvider.m in Sources */,
 				736A2760125845000078F4FE /* GBApplicationSettingsProvider.m in Sources */,
 				7321D0E712944CF500796DEC /* GBTemplateHandler.m in Sources */,

--- a/appledoc.xcodeproj/project.pbxproj
+++ b/appledoc.xcodeproj/project.pbxproj
@@ -201,8 +201,8 @@
 		B8BBC0F7196DFAEB006F239D /* dd_getopt_long-fbsd.m in Sources */ = {isa = PBXBuildFile; fileRef = DA77C690196BEB2C0018A48F /* dd_getopt_long-fbsd.m */; };
 		B8F381D6197D5AAB002F8B92 /* libGRMustache7-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B8F381D5197D5AAB002F8B92 /* libGRMustache7-iOS.a */; };
 		B8F381D7197D5ABE002F8B92 /* libGRMustache7-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B8F381D5197D5AAB002F8B92 /* libGRMustache7-iOS.a */; };
-		C8005C981B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m in Sources */ = {isa = PBXBuildFile; fileRef = C8005C971B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m */; };
-		C8005C991B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m in Sources */ = {isa = PBXBuildFile; fileRef = C8005C971B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m */; };
+		C8005C9D1B9E016400F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m in Sources */ = {isa = PBXBuildFile; fileRef = C8005C9C1B9E016400F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m */; };
+		C8005C9E1B9E016400F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m in Sources */ = {isa = PBXBuildFile; fileRef = C8005C9C1B9E016400F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m */; };
 		D4B844EC17A121040012C1DC /* GBTypedefEnumData.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B844EB17A121030012C1DC /* GBTypedefEnumData.m */; };
 		D4B844EF17A122670012C1DC /* GBEnumConstantData.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B844EE17A122650012C1DC /* GBEnumConstantData.m */; };
 		D4B844F217A122A60012C1DC /* GBEnumConstantProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B844F117A122A50012C1DC /* GBEnumConstantProvider.m */; };
@@ -513,8 +513,8 @@
 		C5676812195840BD00E8E4C8 /* GBTypedefBlockArgument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GBTypedefBlockArgument.h; sourceTree = "<group>"; };
 		C5676813195840BD00E8E4C8 /* GBTypedefBlockArgument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GBTypedefBlockArgument.m; sourceTree = "<group>"; };
 		C5996C98195B0E55007E9AAC /* SynthesizeSingleton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SynthesizeSingleton.h; sourceTree = "<group>"; };
-		C8005C961B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "GBCommentsProcessor+CodeBlockProcessing.h"; path = "../../../appledoc/Processing/GBCommentsProcessor+CodeBlockProcessing.h"; sourceTree = "<group>"; };
-		C8005C971B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "GBCommentsProcessor+CodeBlockProcessing.m"; path = "../../../appledoc/Processing/GBCommentsProcessor+CodeBlockProcessing.m"; sourceTree = "<group>"; };
+		C8005C9B1B9E016400F91ECC /* GBCommentsProcessor+CodeBlockProcessing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GBCommentsProcessor+CodeBlockProcessing.h"; sourceTree = "<group>"; };
+		C8005C9C1B9E016400F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "GBCommentsProcessor+CodeBlockProcessing.m"; sourceTree = "<group>"; };
 		D45D15E117D883C700B7976A /* CommentsFormattingStyle.markdown */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CommentsFormattingStyle.markdown; sourceTree = "<group>"; };
 		D4B844EA17A121000012C1DC /* GBTypedefEnumData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GBTypedefEnumData.h; sourceTree = "<group>"; };
 		D4B844EB17A121030012C1DC /* GBTypedefEnumData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GBTypedefEnumData.m; sourceTree = "<group>"; };
@@ -881,8 +881,8 @@
 		73F70DF41227C23900D19EBA /* Processing */ = {
 			isa = PBXGroup;
 			children = (
-				C8005C961B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.h */,
-				C8005C971B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m */,
+				C8005C9B1B9E016400F91ECC /* GBCommentsProcessor+CodeBlockProcessing.h */,
+				C8005C9C1B9E016400F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m */,
 				73F2CA72123E4161009B406B /* GBProcessor.h */,
 				73F2CA73123E4161009B406B /* GBProcessor.m */,
 				73F2CA70123E4161009B406B /* GBCommentsProcessor.h */,
@@ -1335,7 +1335,7 @@
 				73F2CA74123E4161009B406B /* GBCommentsProcessor.m in Sources */,
 				73F2CA75123E4161009B406B /* GBProcessor.m in Sources */,
 				7307B311124A1929007EC6B8 /* GBObjectiveCParser-SectionsParsingTesting.m in Sources */,
-				C8005C991B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m in Sources */,
+				C8005C9E1B9E016400F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m in Sources */,
 				7307B31A124A1C2E007EC6B8 /* GBMethodSectionData.m in Sources */,
 				736B2BF6124BCBB6009145B1 /* GBSourceInfo.m in Sources */,
 				739AD57F1255C3E600B642C3 /* GBApplicationStringsProvider.m in Sources */,
@@ -1427,7 +1427,7 @@
 				73AA9F731253BF4000074152 /* GBGenerator.m in Sources */,
 				DA77C691196BEB2C0018A48F /* dd_getopt_long-fbsd.m in Sources */,
 				739AD5801255C3E600B642C3 /* GBApplicationStringsProvider.m in Sources */,
-				C8005C981B9C146B00F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m in Sources */,
+				C8005C9D1B9E016400F91ECC /* GBCommentsProcessor+CodeBlockProcessing.m in Sources */,
 				739AD6301255D8CB00B642C3 /* GBHTMLTemplateVariablesProvider.m in Sources */,
 				736A2760125845000078F4FE /* GBApplicationSettingsProvider.m in Sources */,
 				7321D0E712944CF500796DEC /* GBTemplateHandler.m in Sources */,


### PR DESCRIPTION
Appledoc gives warnings when it encounters parsing issues inside
source code blocks.  In particular, it looks for style markup and
reference links.  These are especially bad within ObjectiveC
source code example blocks because of the ObjectiveC bracket
syntax and the obligatory underscores for category methods on
Cocoa classes.

This is similar to bug #72, but not exactly.  I noticed that in
another similar report, these issues are gone in version 3, so I
didn't bother trying to fix this completely.

Basically, the code intercepts the markdown processing, and looks
for any sections within documentation blocks that are marked with
either @code/@endcode of the ~~~/~~~ and ```/``` markdown syntax.

If it finds those blocks, it will output them as markup (making
sure to use the backtick format), and skip any further processing
for that block of text.