### PR TITLE
This fix addresses three related issues.

### DIFF
--- a/Application/GBCommentComponentsProvider.m
+++ b/Application/GBCommentComponentsProvider.m
@@ -97,7 +97,7 @@
 #pragma mark Markdown detection
 
 - (NSString *)markdownInlineLinkRegex {
-	GBRETURN_ON_DEMAND(@"(?:\\[((?:[^]]+)|(?:\\[[^]]+\\]))\\]\\(([^\\s]+)(?:\\s*\"([^\"]+)\")?\\))");
+    GBRETURN_ON_DEMAND(@"!?(?:\\[((?:!\\[[^]]+?\\]\\([^)]+?\\))|(?:\\[[^]]+?\\])|(?:[^]]+?))\\]\\(([^\\s]+)(?:\\s*\"([^\"]+)\")?\\))");
 }
 
 - (NSString *)markdownReferenceLinkRegex {

--- a/Testing/GBApplicationSettingsProviderTesting.m
+++ b/Testing/GBApplicationSettingsProviderTesting.m
@@ -475,14 +475,21 @@
 	settings2.embedCrossReferencesWhenProcessingMarkdown = NO;
 	// execute
 	NSString *result11 = [settings1 stringByEmbeddingCrossReference:@"[description](address \"title\")"];
-	NSString *result12 = [settings1 stringByEmbeddingCrossReference:@"[`description`](address \"title\")"];
+    NSString *result12 = [settings1 stringByEmbeddingCrossReference:@"[`description`](address \"title\")"];
+    NSString *result13 = [settings1 stringByEmbeddingCrossReference:@"![Some Stuff](https://foo.bar/blarg/flip%2flop.xyz)]"];
+
 	NSString *result21 = [settings2 stringByEmbeddingCrossReference:@"[description](address \"title\")"];
 	NSString *result22 = [settings2 stringByEmbeddingCrossReference:@"[`description`](address \"title\")"];
+    NSString *result23 = [settings2 stringByEmbeddingCrossReference:@"![Some Stuff](https://foo.bar/blarg/flip%2flop.xyz)]"];
+
 	// verify
 	assertThat(result11, is(@"~!@[description](address \"title\")@!~"));
-	assertThat(result12, is(@"~!@[`description`](address \"title\")@!~"));
+    assertThat(result12, is(@"~!@[`description`](address \"title\")@!~"));
+    assertThat(result13, is(@"~!@![Some Stuff](https://foo.bar/blarg/flip%2flop.xyz)]@!~"));
+
 	assertThat(result21, is(@"[description](address \"title\")"));
 	assertThat(result22, is(@"[`description`](address \"title\")"));
+    assertThat(result23, is(@"![Some Stuff](https://foo.bar/blarg/flip%2flop.xyz)]"));
 }
 
 #pragma mark Markdown to HTML conversion
@@ -493,9 +500,13 @@
 	// execute
 	NSString *result1 = [settings stringByConvertingMarkdownToHTML:@"~!@[description](address)@!~"];
 	NSString *result2 = [settings stringByConvertingMarkdownToHTML:@"[description](address)"];
+    NSString *result3 = [settings stringByConvertingMarkdownToHTML:@"![alt text](https://xyz/foo.bar)]"];
+    NSString *result4 = [settings stringByConvertingMarkdownToHTML:@"[![alt text](https://xyz/foo.bar)](https://xyz/foo.blarg)"];
 	// verify - Discount converts any kind of link, we just need to strip embedded prefix and suffix!
 	assertThat(result1, is(@"<p><a href=\"address\">description</a></p>"));
-	assertThat(result2, is(@"<p><a href=\"address\">description</a></p>"));
+    assertThat(result2, is(@"<p><a href=\"address\">description</a></p>"));
+    assertThat(result3, is(@"<p><img src=\"https://xyz/foo.bar\" alt=\"alt text\" />]</p>"));
+    assertThat(result4, is(@"<p><a href=\"https://xyz/foo.blarg\"><img src=\"https://xyz/foo.bar\" alt=\"alt text\" /></a></p>"));
 }
 
 - (void)testStringByConvertingMarkdownToHTML_shouldAllowUsageOfUTF8CharacterSet {

--- a/Testing/GBCommentsProcessor-MarkdownTesting.m
+++ b/Testing/GBCommentsProcessor-MarkdownTesting.m
@@ -164,6 +164,90 @@
 	[self assertComment:comment2 matchesLongDescMarkdown:@"**~!$[Protocol](Protocols/Protocol.html)$!~**", nil];
 }
 
+- (void)testProcessCommentWithContextStore_markdown_shouldProperlyFormatImageReferenceLinks {
+    // setup
+    GBStore *store = [self storeWithDefaultObjects];
+    id settings1 = [GBTestObjectsRegistry realSettingsProvider];
+    [settings1 setEmbedCrossReferencesWhenProcessingMarkdown:NO];
+    GBCommentsProcessor *processor1 = [GBCommentsProcessor processorWithSettingsProvider:settings1];
+    GBComment *comment1 = [GBComment commentWithStringValue:@"![alt info](http://foo/bar.blarg)"];
+    id settings2 = [GBTestObjectsRegistry realSettingsProvider];
+    [settings2 setEmbedCrossReferencesWhenProcessingMarkdown:YES];
+    GBCommentsProcessor *processor2 = [GBCommentsProcessor processorWithSettingsProvider:settings2];
+    GBComment *comment2 = [GBComment commentWithStringValue:@"![alt info](http://foo/bar.blarg)"];
+    // execute
+    [processor1 processComment:comment1 withContext:nil store:store];
+    [processor2 processComment:comment2 withContext:nil store:store];
+    // verify
+    [self assertComment:comment1 matchesLongDescMarkdown:@"![alt info](http://foo/bar.blarg)", nil];
+    [self assertComment:comment2 matchesLongDescMarkdown:@"~!@![alt info](http://foo/bar.blarg)@!~", nil];
+}
+
+- (void)testProcessCommentWithContextStore_markdown_shouldProperlyFormatImageReferenceLinksWithPercentChars {
+    // setup
+    GBStore *store = [self storeWithDefaultObjects];
+    id settings1 = [GBTestObjectsRegistry realSettingsProvider];
+    [settings1 setEmbedCrossReferencesWhenProcessingMarkdown:NO];
+    GBCommentsProcessor *processor1 = [GBCommentsProcessor processorWithSettingsProvider:settings1];
+    NSString *raw = @"![alt info](http://foo/bar.%2.blarg \"foo%20bar\")";
+    GBComment *comment1 = [GBComment commentWithStringValue:raw];
+    id settings2 = [GBTestObjectsRegistry realSettingsProvider];
+    [settings2 setEmbedCrossReferencesWhenProcessingMarkdown:YES];
+    GBCommentsProcessor *processor2 = [GBCommentsProcessor processorWithSettingsProvider:settings2];
+    GBComment *comment2 = [GBComment commentWithStringValue:raw];
+    // execute
+    [processor1 processComment:comment1 withContext:nil store:store];
+    [processor2 processComment:comment2 withContext:nil store:store];
+    // verify
+    [self assertComment:comment1 matchesLongDescMarkdown:raw, nil];
+    [self assertComment:comment2 matchesLongDescMarkdown:[NSString stringWithFormat:@"~!@%@@!~", raw], nil];
+}
+
+- (void)testProcessCommentWithContextStore_markdown_shouldProperlyFormatNestedImageReferenceLinks {
+    // setup
+    GBStore *store = [self storeWithDefaultObjects];
+    id settings1 = [GBTestObjectsRegistry realSettingsProvider];
+    [settings1 setEmbedCrossReferencesWhenProcessingMarkdown:NO];
+    GBCommentsProcessor *processor1 = [GBCommentsProcessor processorWithSettingsProvider:settings1];
+    GBComment *comment1 = [GBComment commentWithStringValue:@"[![alt info](http://foo/bar.blarg)](http://foo/bar.blip)"];
+    id settings2 = [GBTestObjectsRegistry realSettingsProvider];
+    [settings2 setEmbedCrossReferencesWhenProcessingMarkdown:YES];
+    GBCommentsProcessor *processor2 = [GBCommentsProcessor processorWithSettingsProvider:settings2];
+    GBComment *comment2 = [GBComment commentWithStringValue:@"[![alt info](http://foo/bar.blarg)](http://foo/bar.blip)"];
+    // execute
+    [processor1 processComment:comment1 withContext:nil store:store];
+    [processor2 processComment:comment2 withContext:nil store:store];
+    // verify
+    [self assertComment:comment1 matchesLongDescMarkdown:@"[![alt info](http://foo/bar.blarg)](http://foo/bar.blip)", nil];
+    [self assertComment:comment2 matchesLongDescMarkdown:@"~!@[![alt info](http://foo/bar.blarg)](http://foo/bar.blip)@!~", nil];
+}
+
+- (void)testProcessCommentWithContextStore_markdown_shouldProperlyFormatMultipleNestedImageReferenceLinks {
+    // setup
+    GBStore *store = [self storeWithDefaultObjects];
+    id settings1 = [GBTestObjectsRegistry realSettingsProvider];
+    [settings1 setEmbedCrossReferencesWhenProcessingMarkdown:NO];
+    GBCommentsProcessor *processor1 = [GBCommentsProcessor processorWithSettingsProvider:settings1];
+    NSArray *rawStrings =
+    @[@"[![Foo version](https://foo.io/bar/blarg%2blip.abc)](https://github.com/no%8body/Repo/releases)",
+      @"[![Bar compatible](https://foo.io/bar/blargblip.abc?style=%20)](https://github.com/no%20body/empty%1)",
+      @"[![Baz license](https://foo.io/bar/blargblip.abc)](https://raw.githubusercontent.com/no%20body/empty%1)"];
+    NSString *raw = [rawStrings componentsJoinedByString:@" some text "];
+    GBComment *comment1 = [GBComment commentWithStringValue:raw];
+    id settings2 = [GBTestObjectsRegistry realSettingsProvider];
+    [settings2 setEmbedCrossReferencesWhenProcessingMarkdown:YES];
+    GBCommentsProcessor *processor2 = [GBCommentsProcessor processorWithSettingsProvider:settings2];
+    GBComment *comment2 = [GBComment commentWithStringValue:raw];
+    // execute
+    [processor1 processComment:comment1 withContext:nil store:store];
+    [processor2 processComment:comment2 withContext:nil store:store];
+    // verify
+    NSString *expected = raw;
+    [self assertComment:comment1 matchesLongDescMarkdown:raw, nil];
+    expected = [NSString stringWithFormat:@"~!@%@@!~", [rawStrings componentsJoinedByString:@"@!~ some text ~!@"]];
+    [self assertComment:comment2 matchesLongDescMarkdown:expected, nil];
+}
+
 - (void)testProcessCommentWithContextStore_markdown_shouldProperlyFormatInlineLinksWhenEmbeddingIsTurnedOn {
 	// setup
 	GBStore *store = [self storeWithDefaultObjects];

--- a/Testing/GBCommentsProcessor-PreprocessingTesting.m
+++ b/Testing/GBCommentsProcessor-PreprocessingTesting.m
@@ -123,9 +123,11 @@
 	// setup
 	GBCommentsProcessor *processor = [self defaultProcessor];
 	// execute
-	NSString *result = [processor stringByPreprocessingString:@"[test_test](http://www.example.com/test_test.html)" withFlags:0];
+    NSString *result = [processor stringByPreprocessingString:@"[test_test](http://www.example.com/test_test.html)" withFlags:0];
+    NSString *result2 = [processor stringByPreprocessingString:@"![test_test](http://www.example.com/test_test.html)" withFlags:0];
 	// verify
-	assertThat(result, is(@"[test_test](http://www.example.com/test_test.html)"));
+    assertThat(result, is(@"[test_test](http://www.example.com/test_test.html)"));
+    assertThat(result2, is(@"![test_test](http://www.example.com/test_test.html)"));
 }
 
 - (void)testStringByPreprocessingString_shouldConvertCodeBlockToMarkdownBackticks {
@@ -589,10 +591,14 @@
 	GBCommentsProcessor *processor = [self processorWithStore:nil];
 	// execute
 	NSString *result1 = [processor stringByConvertingCrossReferencesInString:@"[text](something)" withFlags:0];
-	NSString *result2 = [processor stringByConvertingCrossReferencesInString:@"[multi word](more words)" withFlags:0];
+    NSString *result2 = [processor stringByConvertingCrossReferencesInString:@"[multi word](more words)" withFlags:0];
+    NSString *result3 = [processor stringByConvertingCrossReferencesInString:@"![multi word](more words)" withFlags:0];
+    NSString *result4 = [processor stringByConvertingCrossReferencesInString:@"[![multi word](more words)](foo)" withFlags:0];
 	// verify
 	assertThat(result1, is(@"[text](something)"));
-	assertThat(result2, is(@"[multi word](more words)"));
+    assertThat(result2, is(@"[multi word](more words)"));
+    assertThat(result3, is(@"![multi word](more words)"));
+    assertThat(result4, is(@"[![multi word](more words)](foo)"));
 }
 
 - (void)testStringByConvertingCrossReferencesInString_shouldKeepManualURLLinks {
@@ -606,6 +612,9 @@
 	NSString *result5 = [processor stringByConvertingCrossReferencesInString:@"[text](news://ab.com)" withFlags:0];
 	NSString *result6 = [processor stringByConvertingCrossReferencesInString:@"[text](rss://ab.com)" withFlags:0];
 	NSString *result7 = [processor stringByConvertingCrossReferencesInString:@"[text](mailto:a@b.com)" withFlags:0];
+    NSString *result8 = [processor stringByConvertingCrossReferencesInString:@"![text](http://ab.com)" withFlags:0];
+    NSString *result9 = [processor stringByConvertingCrossReferencesInString:@"[![text](https://ab.com)](https://zx.com)" withFlags:0];
+
 	// verify
 	assertThat(result1, is(@"[text](http://ab.com)"));
 	assertThat(result2, is(@"[text](https://ab.com)"));
@@ -613,7 +622,9 @@
 	assertThat(result4, is(@"[text](ftps://ab.com)"));
 	assertThat(result5, is(@"[text](news://ab.com)"));
 	assertThat(result6, is(@"[text](rss://ab.com)"));
-	assertThat(result7, is(@"[text](mailto:a@b.com)"));
+    assertThat(result7, is(@"[text](mailto:a@b.com)"));
+    assertThat(result8, is(@"![text](http://ab.com)"));
+    assertThat(result9, is(@"[![text](https://ab.com)](https://zx.com)"));
 }
 
 - (void)testStringByConvertingCrossReferencesInString_shouldKeepManualObjectLinksAndUpdateAddress {


### PR DESCRIPTION
1. Image links were not being generated right. Specifically, `![foo](http://foo/bar.baz)` was generating invalid HTML.

2. Image links with a separate href were not generated right.  Specifically, `[![foo](http://foo/bar.baz)](http://foo/bar.other)` was generating invalid HTML.

3. Percent sign in link was being used as C-string format specifier.  Specifically, `[![foo](http://foo/bar.baz%2biz)](http://foo/bar.other)` was generating invalid HTML.

**NOTE** Both #555 and #557 are independent and fix separate issues.  However, the two changes will create a merge conflict.  I know what needs to be done to cleanly merge both, and will watch the upstream repository and update the other branch accordingly so that it may be cleanly merged.

---
**EDIT** Just in case...

In my own fork, I merged #557 first, then #555, and [this commit](https://github.com/jodyhagins/appledoc/commit/2e18fff95daa8f31dae6f0d86840c32761e34e19) was necessary to address the merge issue.  Not too bad.

