### PR TITLE
Use application settings to enable skipping the preprocess stage for …

### DIFF
--- a/Application/GBAppledocApplication.m
+++ b/Application/GBAppledocApplication.m
@@ -45,6 +45,7 @@ static char *kGBArgKeepIntermediateFiles = "keep-intermediate-files";
 static char *kGBArgExitCodeThreshold = "exit-threshold";
 static char *kGBArgDocsSectionTitle = "docs-section-title";
 
+static char *kGBArgSkipCodeBlockMarker = "skip-code-block-marker";
 static char *kGBArgRepeatFirstParagraph = "repeat-first-par";
 static char *kGBArgPreprocessHeaderDoc = "preprocess-headerdoc";
 static char *kGBArgPrintInformationBlockTitles = "print-information-block-titles";
@@ -286,7 +287,8 @@ static char *kGBArgHelp = "help";
 		{ kGBArgCrossRefFormat,												0,		DDGetoptRequiredArgument },
 		{ kGBArgExplicitCrossRef,											0,		DDGetoptNoArgument },
 		{ GBNoArg(kGBArgExplicitCrossRef),									0,		DDGetoptNoArgument },
-		
+
+        { kGBArgSkipCodeBlockMarker,										0,		DDGetoptRequiredArgument },
 		{ kGBArgKeepIntermediateFiles,										0,		DDGetoptNoArgument },
 		{ kGBArgKeepUndocumentedObjects,									0,		DDGetoptNoArgument },
 		{ kGBArgKeepUndocumentedMembers,									0,		DDGetoptNoArgument },
@@ -807,6 +809,9 @@ static char *kGBArgHelp = "help";
 - (void)setHtmlAnchors:(NSString *)value {
     self.settings.htmlAnchorFormat = GBHTMLAnchorFormatFromNSString(value);
 }
+- (void)setSkipCodeBlockMarker:(NSString *)marker {
+	[self.settings addSkipCodeBlockMarker:marker];
+}
 - (void)setNoCleanOutput:(BOOL)value { self.settings.cleanupOutputPathBeforeRunning = !value; }
 - (void)setNoCreateHtml:(BOOL)value { [self setCreateHtml:!value]; }
 - (void)setNoCreateDocset:(BOOL)value { [self setCreateDocset:!value]; }
@@ -953,7 +958,8 @@ static char *kGBArgHelp = "help";
     ddprintf(@"--%s = %@\n", kGBArgDocSetXMLFilename, self.settings.docsetXMLFilename);
     ddprintf(@"--%s = %@\n", kGBArgDocSetPackageFilename, self.settings.docsetPackageFilename);
     ddprintf(@"\n");
-    
+
+    for (NSString *marker in self.settings.skipCodeBlockMarkers) ddprintf(@"--%s = %@\n", kGBArgSkipCodeBlockMarker, marker);
     ddprintf(@"--%s = %@\n", kGBArgCleanOutput, PRINT_BOOL(self.settings.cleanupOutputPathBeforeRunning));
     ddprintf(@"--%s = %@\n", kGBArgCreateHTML, PRINT_BOOL(self.settings.createHTML));
     ddprintf(@"--%s = %@\n", kGBArgCreateDocSet, PRINT_BOOL(self.settings.createDocSet));
@@ -1048,6 +1054,7 @@ static char *kGBArgHelp = "help";
     PRINT_USAGE(@"   ", kGBArgCrossRefFormat, @"<string>", @"Cross reference template regex");
     PRINT_USAGE(@"   ", kGBArgExitCodeThreshold, @"<number>", @"Exit code threshold below which 0 is returned");
 	PRINT_USAGE(@"   ", kGBArgDocsSectionTitle, @"<string>", @"Title of the documentation section (defaults to \"Programming Guides\"");
+    PRINT_USAGE(@"   ", kGBArgSkipCodeBlockMarker, @"<marker>", @"Text to mark begin/end of code block for which preprocessing is skipped");
     ddprintf(@"\n");
 	ddprintf(@"WARNINGS\n");
 	PRINT_USAGE(@"   ", kGBArgWarnOnMissingOutputPath, @"", @"[b] Warn if output path is not given");

--- a/Application/GBApplicationSettingsProvider.h
+++ b/Application/GBApplicationSettingsProvider.h
@@ -212,6 +212,31 @@ NSString *NSStringFromGBPublishedFeedFormats(GBPublishedFeedFormats format);
 /// @name Behavior handling
 ///---------------------------------------------------------------------------------------
 
+/** The markers to use when matching source code blocks that will forgo preprocessing.
+
+ Text between these markers will be treated as source-code blocks, and not preprocessed.
+ */
+@property (strong, readonly) NSArray *skipCodeBlockMarkers;
+
+/** The actual regex patterns to use when matching source code blocks that will forgo preprocessing.
+
+ The patterns are computed when the markers are added.
+ */
+@property (strong, readonly) NSArray *skipCodeBlockPatterns;
+
+/**
+ Add a marker to be used when searching for code blocks that should skip preprocessing.
+
+ @param marker A marker.  The marker defines the beginning and ending tokens that deliniate a source-code-block.  The begin/end markers are separated by a forward-slash.  If there is no forward-slash, then the same pattern is used for both the begin and end markers.
+
+ When scanning the source text, any text that is between the two markers will be treated as source code, and will skip the preprocessing step.  Specifically, reference links will not be discovered within that block.  To match, the begin/end markers must be on lines all by themselves with nothing else but whitespace.
+
+ For example, a marker of "@code/@endcode" will mark all the text in between as source code, and will not try to match reference links inside.  Similarly, a marker of "~~~~~" will do the same thing for all the text between two lines with "~~~~~" on them.
+
+ @note Markers are checked in the order in which they are added.  Duplicates are dropped, and not added.
+ */
+- (void)addSkipCodeBlockMarker:(NSString *)marker;
+
 /** Indicates whether HTML files should be generated or not.
  
  If `YES`, HTML files are generated in `outputPath` from parsed and processed data. If `NO`, input files are parsed and processed, but nothing is generated.

--- a/Testing/GBCommentsProcessor-PreprocessingTesting.m
+++ b/Testing/GBCommentsProcessor-PreprocessingTesting.m
@@ -130,36 +130,43 @@
     assertThat(result2, is(@"![test_test](http://www.example.com/test_test.html)"));
 }
 
-- (void)testStringByPreprocessingString_shouldConvertCodeBlockToMarkdownBackticks {
+- (void)testStringByPreprocessingString_shouldNotConvertCodeBlockToMarkdownBackticksIfNotInSettings {
     // setup
     GBCommentsProcessor *processor = [self defaultProcessor];
+    // execute
+    NSString *result = [processor stringByPreprocessingString:@"\n  @code  \n[self doSomething];\n  @endcode  \n" withFlags:0];
+    // verify
+    assertThat(result, is(@"\n  @code  \n[self doSomething];\n  @endcode  \n"));
+}
+
+- (void)testStringByPreprocessingString_shouldConvertSkipCodeBlockBeginEndMarkersToMarkdownBackticks {
+    // setup
+    id settings = [GBTestObjectsRegistry realSettingsProvider];
+    [settings addSkipCodeBlockMarker:@"@code/@endcode"];
+    GBCommentsProcessor *processor = [GBCommentsProcessor processorWithSettingsProvider:settings];
     // execute
     NSString *result = [processor stringByPreprocessingString:@"\n  @code  \n[self doSomething];\n  @endcode  \n" withFlags:0];
     // verify
     assertThat(result, is(@"\n```\n[self doSomething];\n```\n"));
 }
 
-- (void)testStringByPreprocessingString_shouldConvertTildeCodeBlockToMarkdownBackticks {
+- (void)testStringByPreprocessingString_shouldConvertSkipCodeBlockSingleMarkerToMarkdownBackticks {
     // setup
-    GBCommentsProcessor *processor = [self defaultProcessor];
+    id settings = [GBTestObjectsRegistry realSettingsProvider];
+    [settings addSkipCodeBlockMarker:@"~~~"];
+    GBCommentsProcessor *processor = [GBCommentsProcessor processorWithSettingsProvider:settings];
     // execute
     NSString *result = [processor stringByPreprocessingString:@"\n  ~~~  \n[self doSomething];\n  ~~~  \n" withFlags:0];
     // verify
     assertThat(result, is(@"\n```\n[self doSomething];\n```\n"));
 }
 
-- (void)testStringByPreprocessingString_shouldConvertBacktickCodeBlockToMarkdownBackticks {
+- (void)testStringByPreprocessingString_shouldConvertSkipCodeBlockMultipleMarkersToMarkdownBackticks {
     // setup
-    GBCommentsProcessor *processor = [self defaultProcessor];
-    // execute
-    NSString *result = [processor stringByPreprocessingString:@"\n  ```  \n[self doSomething];\n  ```  \n" withFlags:0];
-    // verify
-    assertThat(result, is(@"\n```\n[self doSomething];\n```\n"));
-}
-
-- (void)testStringByPreprocessingString_shouldConvertMultipleCodeBlocksToMarkdownBackticks {
-    // setup
-    GBCommentsProcessor *processor = [self defaultProcessor];
+    id settings = [GBTestObjectsRegistry realSettingsProvider];
+    [settings addSkipCodeBlockMarker:@"```"];
+    [settings addSkipCodeBlockMarker:@"@code/@endcode"];
+    GBCommentsProcessor *processor = [GBCommentsProcessor processorWithSettingsProvider:settings];
     NSString *raw = @"\n  @code  \n[self doSomething];\n  @endcode  \n\n  @code  \n[self doSomething];\n  @endcode  \n";
     NSString *expected = @"\n```\n[self doSomething];\n```\n\n```\n[self doSomething];\n```\n";
     // execute


### PR DESCRIPTION
…source-code blocks

This makes the feature in #555 configurable via the settings.  Some people may want the old behavior.  Thus, I made the default act like it did before (though #535 is similar but is explicitly for backticks), and you must opt-in to get the new behavior.

I can change the default easily enough, if so desired.

With this change, you specify the markers you want to be recognized as part of the settings.

If merged, I can go edit the github wiki and add an explanation for this setting.