### PR TITLE
Applied modern syntax and fixed issue NSCalendar issue that required compiling against OS X 10.9 SDK.

### DIFF
--- a/Application/GBAppledocApplication.m
+++ b/Application/GBAppledocApplication.m
@@ -535,7 +535,7 @@ static char *kGBArgHelp = "help";
     //check if even deal with a project
     if([arguments count] < 2)
         return;
-    NSString *path = [arguments objectAtIndex:1];
+    NSString *path = arguments[1];
     if(![path.pathExtension isEqualToString:@"xcodeproj"])
         return;
 
@@ -995,16 +995,16 @@ static char *kGBArgHelp = "help";
 }
 
 - (void)printVersion {
-	NSString *appledocName = [self.settings.stringTemplates.appledocData objectForKey:@"tool"];
-	NSString *appledocVersion = [self.settings.stringTemplates.appledocData objectForKey:@"version"];
-	NSString *appledocBuild = [self.settings.stringTemplates.appledocData objectForKey:@"build"];
+	NSString *appledocName = self.settings.stringTemplates.appledocData[@"tool"];
+	NSString *appledocVersion = self.settings.stringTemplates.appledocData[@"version"];
+	NSString *appledocBuild = self.settings.stringTemplates.appledocData[@"build"];
 	ddprintf(@"%@ version: %@ (build %@)\n", appledocName, appledocVersion, appledocBuild);
 	ddprintf(@"\n");
 }
 
 - (void)printHelp {
 #define PRINT_USAGE(short,long,arg,desc) [self printHelpForShortOption:short longOption:[NSString stringWithUTF8String:long] argument:arg description:desc]
-	NSString *name = [self.settings.stringTemplates.appledocData objectForKey:@"tool"];
+	NSString *name = self.settings.stringTemplates.appledocData[@"tool"];
 	ddprintf(@"Usage: %@ [OPTIONS] <paths to source dirs or files>\n", name);
 	ddprintf(@"\n");
 	ddprintf(@"PATHS\n");

--- a/Application/GBApplicationSettingsProvider.m
+++ b/Application/GBApplicationSettingsProvider.m
@@ -267,7 +267,7 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBApplicationSettingsProvider, sharedApplicationS
 			if (!insideCode) return linkText;
 			NSArray *components = [linkText captureComponentsMatchedByRegex:self.commentComponents.markdownInlineLinkRegex];
 			if ([components count] < 1) return linkText;
-			return [components objectAtIndex:1];
+			return components[1];
 		}];
 	}
 
@@ -454,8 +454,7 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBApplicationSettingsProvider, sharedApplicationS
 
 - (BOOL)isPathRepresentingTemplateFile:(NSString *)path {
 	NSString *filename = [[path lastPathComponent] stringByDeletingPathExtension];
-	if ([filename hasSuffix:@"-template"]) return YES;
-	return NO;
+	return [filename hasSuffix:@"-template"];
 }
 
 - (NSString *)outputFilenameForTemplatePath:(NSString *)path {
@@ -583,9 +582,7 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBApplicationSettingsProvider, sharedApplicationS
 #pragma mark Helper methods
 
 - (BOOL)isTopLevelStoreObject:(id)object {
-	if ([object isKindOfClass:[GBClassData class]] || [object isKindOfClass:[GBCategoryData class]] || [object isKindOfClass:[GBProtocolData class]])
-		return YES;
-	return NO;
+	return [object isKindOfClass:[GBClassData class]] || [object isKindOfClass:[GBCategoryData class]] || [object isKindOfClass:[GBProtocolData class]];
 }
 
 - (NSString *)stringByReplacingOccurencesOfPlaceholdersInString:(NSString *)string {

--- a/Application/GBApplicationStringsProvider.m
+++ b/Application/GBApplicationStringsProvider.m
@@ -22,14 +22,14 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		[result setObject:@"%@ Class Reference" forKey:@"classTitle"];
-		[result setObject:@"%1$@(%2$@) Category Reference" forKey:@"categoryTitle"];
-		[result setObject:@"%@ Protocol Reference" forKey:@"protocolTitle"];
-		[result setObject:@"%@ Constants Reference" forKey:@"constantTitle"];
-        [result setObject:@"%@ Block Reference" forKey:@"blockTitle"];
-		[result setObject:@"%@ Methods" forKey:@"mergedCategorySectionTitle"];
-		[result setObject:@"Extension Methods" forKey:@"mergedExtensionSectionTitle"];
-		[result setObject:@"%2$@ from %1$@" forKey:@"mergedPrefixedCategorySectionTitle"];
+		result[@"classTitle"] = @"%@ Class Reference";
+		result[@"categoryTitle"] = @"%1$@(%2$@) Category Reference";
+		result[@"protocolTitle"] = @"%@ Protocol Reference";
+		result[@"constantTitle"] = @"%@ Constants Reference";
+        result[@"blockTitle"] = @"%@ Block Reference";
+		result[@"mergedCategorySectionTitle"] = @"%@ Methods";
+		result[@"mergedExtensionSectionTitle"] = @"Extension Methods";
+		result[@"mergedPrefixedCategorySectionTitle"] = @"%2$@ from %1$@";
 	}
 	return result;
 }
@@ -38,12 +38,12 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		[result setObject:@"Inherits from" forKey:@"inheritsFrom"];
-		[result setObject:@"Conforms to" forKey:@"conformsTo"];
-        [result setObject:@"References" forKey:@"references"];
-        [result setObject:@"Availability" forKey:@"availability"];
-		[result setObject:@"Declared in" forKey:@"declaredIn"];
-		[result setObject:@"Companion guide" forKey:@"companionGuide"];
+		result[@"inheritsFrom"] = @"Inherits from";
+		result[@"conformsTo"] = @"Conforms to";
+        result[@"references"] = @"References";
+        result[@"availability"] = @"Availability";
+		result[@"declaredIn"] = @"Declared in";
+		result[@"companionGuide"] = @"Companion guide";
 	}
 	return result;
 }
@@ -52,7 +52,7 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		[result setObject:@"Overview" forKey:@"title"];
+		result[@"title"] = @"Overview";
 	}
 	return result;
 }
@@ -61,10 +61,10 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		[result setObject:@"Tasks" forKey:@"title"];
-		[result setObject:@"Other Methods" forKey:@"otherMethodsSectionName"];
-		[result setObject:@"required method" forKey:@"requiredMethod"];
-		[result setObject:@"property" forKey:@"property"];
+		result[@"title"] = @"Tasks";
+		result[@"otherMethodsSectionName"] = @"Other Methods";
+		result[@"requiredMethod"] = @"required method";
+		result[@"property"] = @"property";
 	}
 	return result;
 }
@@ -73,17 +73,17 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		[result setObject:@"Class Methods" forKey:@"classMethodsTitle"];
-		[result setObject:@"Instance Methods" forKey:@"instanceMethodsTitle"];
-        [result setObject:@"Block Definition" forKey:@"blockDefTitle"];
-		[result setObject:@"Properties" forKey:@"propertiesTitle"];
-		[result setObject:@"Parameters" forKey:@"parametersTitle"];
-		[result setObject:@"Return Value" forKey:@"resultTitle"];
-		[result setObject:@"Availability" forKey:@"availability"];
-		[result setObject:@"Discussion" forKey:@"discussionTitle"];
-		[result setObject:@"Exceptions" forKey:@"exceptionsTitle"];
-		[result setObject:@"See Also" forKey:@"seeAlsoTitle"];
-		[result setObject:@"Declared In" forKey:@"declaredInTitle"];
+		result[@"classMethodsTitle"] = @"Class Methods";
+		result[@"instanceMethodsTitle"] = @"Instance Methods";
+        result[@"blockDefTitle"] = @"Block Definition";
+		result[@"propertiesTitle"] = @"Properties";
+		result[@"parametersTitle"] = @"Parameters";
+		result[@"resultTitle"] = @"Return Value";
+		result[@"availability"] = @"Availability";
+		result[@"discussionTitle"] = @"Discussion";
+		result[@"exceptionsTitle"] = @"Exceptions";
+		result[@"seeAlsoTitle"] = @"See Also";
+		result[@"declaredInTitle"] = @"Declared In";
 	}
 	return result;
 }
@@ -94,7 +94,7 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		[result setObject:@"%@ Document" forKey:@"titleTemplate"];
+		result[@"titleTemplate"] = @"%@ Document";
 	}
 	return result;
 }
@@ -105,13 +105,13 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		[result setObject:@"%@ Reference" forKey:@"titleTemplate"];
-		[result setObject:@"Programming Guides" forKey:@"docsTitle"];
-		[result setObject:@"Class References" forKey:@"classesTitle"];
-		[result setObject:@"Category References" forKey:@"categoriesTitle"];
-		[result setObject:@"Protocol References" forKey:@"protocolsTitle"];
-        [result setObject:@"Constant References" forKey:@"constantsTitle"];
-        [result setObject:@"Block References" forKey:@"blocksTitle"];
+		result[@"titleTemplate"] = @"%@ Reference";
+		result[@"docsTitle"] = @"Programming Guides";
+		result[@"classesTitle"] = @"Class References";
+		result[@"categoriesTitle"] = @"Category References";
+		result[@"protocolsTitle"] = @"Protocol References";
+        result[@"constantsTitle"] = @"Constant References";
+        result[@"blocksTitle"] = @"Block References";
 	}
 	return result;
 }
@@ -120,12 +120,12 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		[result setObject:@"%@ Hierarchy" forKey:@"titleTemplate"];
-		[result setObject:@"Class Hierarchy" forKey:@"classesTitle"];
-		[result setObject:@"Category References" forKey:@"categoriesTitle"];
-		[result setObject:@"Protocol References" forKey:@"protocolsTitle"];
-        [result setObject:@"Constant References" forKey:@"constantsTitle"];
-        [result setObject:@"Block References" forKey:@"blocksTitle"];
+		result[@"titleTemplate"] = @"%@ Hierarchy";
+		result[@"classesTitle"] = @"Class Hierarchy";
+		result[@"categoriesTitle"] = @"Category References";
+		result[@"protocolsTitle"] = @"Protocol References";
+        result[@"constantsTitle"] = @"Constant References";
+        result[@"blocksTitle"] = @"Block References";
 	}
 	return result;
 }
@@ -136,12 +136,12 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		[result setObject:@"Programming Guides" forKey:@"docsTitle"];
-		[result setObject:@"Classes" forKey:@"classesTitle"];
-		[result setObject:@"Categories" forKey:@"categoriesTitle"];
-		[result setObject:@"Protocols" forKey:@"protocolsTitle"];
-        [result setObject:@"Constants" forKey:@"constantsTitle"];
-        [result setObject:@"Blocks" forKey:@"blocksTitle"];
+		result[@"docsTitle"] = @"Programming Guides";
+		result[@"classesTitle"] = @"Classes";
+		result[@"categoriesTitle"] = @"Categories";
+		result[@"protocolsTitle"] = @"Protocols";
+        result[@"constantsTitle"] = @"Constants";
+        result[@"blocksTitle"] = @"Blocks";
 	}
 	return result;
 }
@@ -150,10 +150,10 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		[result setObject:@"appledoc" forKey:@"tool"];
-		[result setObject:@"2.2.1" forKey:@"version"];
-		[result setObject:@"1334" forKey:@"build"];
-		[result setObject:@"http://appledoc.gentlebytes.com" forKey:@"homepage"];
+		result[@"tool"] = @"appledoc";
+		result[@"version"] = @"2.2.1";
+		result[@"build"] = @"1334";
+		result[@"homepage"] = @"http://appledoc.gentlebytes.com";
 	}
 	return result;
 }

--- a/Common/GBTask.m
+++ b/Common/GBTask.m
@@ -91,7 +91,7 @@
 
 - (void)outputHandleDataReceived:(NSNotification *)note {
 	// Report anything received to std out.
-	NSData *data = [[note userInfo] objectForKey:NSFileHandleNotificationDataItem];
+	NSData *data = [note userInfo][NSFileHandleNotificationDataItem];
 	NSString *string = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
 	self.lastStandardOutput = [self.lastStandardOutput stringByAppendingFormat:@"%@\n", string];
 	if (self.reportIndividualLines) {
@@ -105,7 +105,7 @@
 
 - (void)errorHandleDataReceived:(NSNotification *)note {
 	// Only report if something was received. As notification is posted at least once when the task finishes, we should ignore it at that point!
-	NSData *data = [[note userInfo] objectForKey:NSFileHandleNotificationDataItem];
+	NSData *data = [note userInfo][NSFileHandleNotificationDataItem];
 	NSString *string = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
 	if ([string length] > 0) {
 		self.lastStandardError = [self.lastStandardError stringByAppendingFormat:@"%@\n", string];

--- a/Common/NSArray+GBArray.m
+++ b/Common/NSArray+GBArray.m
@@ -12,7 +12,7 @@
 
 - (id)firstObject {
 	if ([self count] == 0) return nil;
-	return [self objectAtIndex:0];
+	return self[0];
 }
 
 - (BOOL)isEmpty {

--- a/Common/NSError+GBError.m
+++ b/Common/NSError+GBError.m
@@ -14,8 +14,8 @@
 	NSMutableDictionary *info = nil;
 	if ([description length] > 0 || [reason length] > 0) {
 		info = [NSMutableDictionary dictionaryWithCapacity:2];
-		if ([description length] > 0) [info setObject:description forKey:NSLocalizedDescriptionKey];
-		if ([reason length] > 0) [info setObject:reason forKey:NSLocalizedFailureReasonErrorKey];
+		if ([description length] > 0) info[NSLocalizedDescriptionKey] = description;
+		if ([reason length] > 0) info[NSLocalizedFailureReasonErrorKey] = reason;
 	}
 	return [self errorWithDomain:@"appledoc" code:code userInfo:info];
 }

--- a/Common/ThirdParty/CocoaLumberjack/DDFileLogger.m
+++ b/Common/ThirdParty/CocoaLumberjack/DDFileLogger.m
@@ -196,7 +196,7 @@
     NSString *baseDir = ([paths count] > 0) ? [paths objectAtIndex:0] : nil;
 #else
 	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
-    NSString *basePath = ([paths count] > 0) ? [paths objectAtIndex:0] : NSTemporaryDirectory();
+    NSString *basePath = ([paths count] > 0) ? paths[0] : NSTemporaryDirectory();
 	
 	NSString *appName = [[NSProcessInfo processInfo] processName];
 	
@@ -885,7 +885,7 @@
 		
 		if ([sortedLogFileInfos count] > 0)
 		{
-			DDLogFileInfo *mostRecentLogFileInfo = [sortedLogFileInfos objectAtIndex:0];
+			DDLogFileInfo *mostRecentLogFileInfo = sortedLogFileInfos[0];
 			
 			BOOL useExistingLogFile = YES;
 			BOOL shouldArchiveMostRecent = NO;
@@ -1069,7 +1069,7 @@
 {
 	if (modificationDate == nil)
 	{
-		modificationDate = [[[self fileAttributes] objectForKey:NSFileModificationDate] retain];
+		modificationDate = [[self fileAttributes][NSFileModificationDate] retain];
 	}
 	
 	return modificationDate;
@@ -1111,7 +1111,7 @@
 		
 	#else
 		
-		creationDate = [[[self fileAttributes] objectForKey:NSFileCreationDate] retain];
+		creationDate = [[self fileAttributes][NSFileCreationDate] retain];
 		
 	#endif
 		
@@ -1123,7 +1123,7 @@
 {
 	if (fileSize == 0)
 	{
-		fileSize = [[[self fileAttributes] objectForKey:NSFileSize] unsignedLongLongValue];
+		fileSize = [[self fileAttributes][NSFileSize] unsignedLongLongValue];
 	}
 	
 	return fileSize;

--- a/Common/ThirdParty/CocoaLumberjack/DDLog.m
+++ b/Common/ThirdParty/CocoaLumberjack/DDLog.m
@@ -550,13 +550,9 @@ static NSUInteger GBStoreLine = 0;
 	
 	Method getter = class_getClassMethod(class, getterSel);
 	Method setter = class_getClassMethod(class, setterSel);
-	
-	if ((getter != NULL) && (setter != NULL))
-	{
-		return YES;
-	}
-	
-	return NO;
+
+	return (getter != NULL) && (setter != NULL);
+
 }
 
 + (NSArray *)registeredClasses

--- a/Common/ThirdParty/DDCli/DDGetoptLongParser.m
+++ b/Common/ThirdParty/DDCli/DDGetoptLongParser.m
@@ -156,10 +156,8 @@ dd_getopt_long_only(int nargc, char * const *nargv, const char *options,
     }
     [self addOption];
     
-    NSArray * optionInfo = [NSArray arrayWithObjects:
-        key, [NSNumber numberWithInt: argumentOptions], nil];
-    [_optionInfoMap setObject: optionInfo
-                       forKey: [NSNumber numberWithInt: shortOptionValue]];
+    NSArray * optionInfo = @[key, @(argumentOptions)];
+    _optionInfoMap[@(shortOptionValue)] = optionInfo;
     
     [_utf8Data addObject: utf8Data];
 }
@@ -188,7 +186,7 @@ dd_getopt_long_only(int nargc, char * const *nargv, const char *options,
     NSUInteger i;
     for (i = 0; i < argc; i++)
     {
-        NSString * argument = [arguments objectAtIndex: i];
+        NSString * argument = arguments[i];
         argv[i] = (char *) [argument UTF8String];
     }
     argv[i] = 0;
@@ -228,20 +226,20 @@ dd_getopt_long_only(int nargc, char * const *nargv, const char *options,
         if (optarg != NULL)
             nsoptarg = [NSString stringWithUTF8String: optarg];
         
-        NSArray * optionInfo = [_optionInfoMap objectForKey: [NSNumber numberWithInt: ch]];
+        NSArray * optionInfo = _optionInfoMap[@(ch)];
         NSAssert(optionInfo != nil, @"optionInfo should not be nil");
 
         if (optionInfo != nil)
         {
-            NSString * key = [optionInfo objectAtIndex: 0];
-            int argumentOptions = [[optionInfo objectAtIndex: 1] intValue];
+            NSString * key = optionInfo[0];
+            int argumentOptions = [optionInfo[1] intValue];
             if (argumentOptions == DDGetoptNoArgument) {
 				BOOL boolValue = YES;
 				if ([key hasPrefix:@"no-"]) {
 					boolValue = NO;
 					key = [key substringFromIndex:3];
 				}
-                [_target setValue: [NSNumber numberWithBool: boolValue] forKey: key];
+                [_target setValue:@(boolValue) forKey:key];
 			}
             else
                 [_target setValue: nsoptarg forKey: key];

--- a/Common/ThirdParty/DDMinizip/src/DDZipReader.m
+++ b/Common/ThirdParty/DDMinizip/src/DDZipReader.m
@@ -154,7 +154,7 @@
 			{
 				NSDate* orgDate = [DDZippedFileInfo dateWithMUDate:fileInfo.tmu_date];
 
-				NSDictionary* attr = [NSDictionary dictionaryWithObject:orgDate forKey:NSFileModificationDate]; //[[NSFileManager defaultManager] fileAttributesAtPath:fullPath traverseLink:YES];
+				NSDictionary* attr = @{NSFileModificationDate : orgDate}; //[[NSFileManager defaultManager] fileAttributesAtPath:fullPath traverseLink:YES];
 				if( attr )
 				{
 				//	[attr  setValue:orgDate forKey:NSFileCreationDate];

--- a/Common/ThirdParty/DDMinizip/src/DDZipWriter.m
+++ b/Common/ThirdParty/DDMinizip/src/DDZipWriter.m
@@ -30,9 +30,7 @@
 -(BOOL) newZipFile:(NSString *)zipFile
 {
 	_zipFile = zipOpen( (const char*)[zipFile UTF8String], 0 );
-	if( !_zipFile ) 
-		return NO;
-	return YES;
+	return _zipFile != NULL;
 }
 
 -(BOOL) addFileToZip:(NSString *)file newname:(NSString *)newname
@@ -48,7 +46,7 @@
 	NSDictionary* attr = [[NSFileManager defaultManager] attributesOfItemAtPath:file error:nil];
 	if( attr )
 	{
-		NSDate* fileDate = (NSDate*)[attr objectForKey:NSFileModificationDate];
+		NSDate* fileDate = (NSDate*) attr[NSFileModificationDate];
 		if( fileDate )
 		{
 			zipInfo.dosDate = [fileDate timeIntervalSinceDate:[DDZippedFileInfo dateWithTimeIntervalSince1980:0]];
@@ -85,7 +83,7 @@
 {
 	if( _zipFile==NULL )
 		return NO;
-	BOOL ret =  zipClose( _zipFile,NULL )==Z_OK?YES:NO;
+	BOOL ret = zipClose( _zipFile,NULL )==Z_OK;
 	_zipFile = NULL;
 	return ret;
 }

--- a/Common/ThirdParty/DDMinizip/src/DDZippedFileInfo.m
+++ b/Common/ThirdParty/DDMinizip/src/DDZippedFileInfo.m
@@ -61,14 +61,14 @@
 	[comps setDay:mu_date.tm_mday];
 	[comps setMonth:mu_date.tm_mon];
     [comps setYear:mu_date.tm_year];
-	NSCalendar *gregorian = [NSCalendar calendarWithIdentifier:NSGregorianCalendar];
+    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
 	NSDate *date = [gregorian dateFromComponents:comps];
 	return date;
 }
 
 +(tm_zip) mzDateWithDate:(NSDate*)date
 {
-	NSCalendar *gregorian = [NSCalendar calendarWithIdentifier:NSGregorianCalendar];
+    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
 	NSDateComponents *comps = [gregorian components:NSSecondCalendarUnit | NSMinuteCalendarUnit | NSHourCalendarUnit | NSDayCalendarUnit | NSMonthCalendarUnit | NSYearCalendarUnit fromDate:date];
     tm_zip mu_date;
     mu_date.tm_sec = (uInt)comps.second;
@@ -89,7 +89,7 @@
 	[comps setDay:1];
 	[comps setMonth:1];
 	[comps setYear:1980];
-	NSCalendar *gregorian = [NSCalendar calendarWithIdentifier:NSGregorianCalendar];
+    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
 	NSDate *date = [gregorian dateFromComponents:comps];
 	
 	return [date dateByAddingTimeInterval:interval];

--- a/Common/ThirdParty/DDUtils/DDEmbeddedDataReader.m
+++ b/Common/ThirdParty/DDUtils/DDEmbeddedDataReader.m
@@ -155,11 +155,9 @@ NSError *_BVPOSIXError(NSURL *url) {
                                                userInfo:nil];
     NSString *errorDescription = [NSString stringWithFormat:@"File %@ could not be opened. %s.",
                                   [url path], strerror(errno)];
-    NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:
-                              errorDescription, NSLocalizedDescriptionKey,
-                              underlyingError, NSUnderlyingErrorKey,
-                              [url path], NSFilePathErrorKey,
-                              nil];
+    NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errorDescription,
+            NSUnderlyingErrorKey : underlyingError,
+            NSFilePathErrorKey : [url path]};
     NSError *error = [[NSError alloc] initWithDomain:BVPlistExtractorErrorDomain
                                                 code:BVPlistExtractorErrorOpenFile
                                             userInfo:userInfo];
@@ -169,10 +167,8 @@ NSError *_BVPOSIXError(NSURL *url) {
 
 NSError *_BVGenericError(NSURL *url, NSString *fileQualifier, NSInteger errorCode) {
     NSString *errorDescription = [NSString stringWithFormat:@"File %@ is %@.", [url path], fileQualifier];
-    NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:
-                              errorDescription, NSLocalizedDescriptionKey,
-                              [url path], NSFilePathErrorKey,
-                              nil];
+    NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errorDescription,
+            NSFilePathErrorKey : [url path]};
     NSError *error = [[NSError alloc] initWithDomain:BVPlistExtractorErrorDomain
                                                 code:errorCode
                                             userInfo:userInfo];

--- a/Generating/GBDocSetInstallGenerator.m
+++ b/Generating/GBDocSetInstallGenerator.m
@@ -47,7 +47,7 @@
 	NSAppleScript* script = [[NSAppleScript alloc] initWithSource:installScript];
 	if (![script executeAndReturnError:&errorDict])
 	{
-		NSString *message = [errorDict objectForKey:NSAppleScriptErrorMessage];
+		NSString *message = errorDict[NSAppleScriptErrorMessage];
 		if (error) *error = [NSError errorWithCode:GBErrorDocSetXcodeReloadFailed description:@"Documentation set was installed, but couldn't reload documentation within Xcode." reason:message];
 		return NO;
 	}

--- a/Generating/GBDocSetPublishGenerator.m
+++ b/Generating/GBDocSetPublishGenerator.m
@@ -63,7 +63,7 @@
 	}
 	
 	// Create destination directory.
-	if (![self initializeDirectoryAtPath:outputDir preserve:[NSArray arrayWithObject:atomName] error:error]) {
+	if (![self initializeDirectoryAtPath:outputDir preserve:@[atomName] error:error]) {
 		GBLogWarn(@"Failed initializing DocSet publish directory '%@'!", outputDir);
 		return NO;
 	}

--- a/Generating/GBHTMLOutputGenerator.m
+++ b/Generating/GBHTMLOutputGenerator.m
@@ -276,19 +276,19 @@
 }
 
 - (GBTemplateHandler *)htmlObjectTemplate {
-	return [self.templateFiles objectForKey:@"object-template.html"];
+	return self.templateFiles[@"object-template.html"];
 }
 
 - (GBTemplateHandler *)htmlIndexTemplate {
-	return [self.templateFiles objectForKey:@"index-template.html"];
+	return self.templateFiles[@"index-template.html"];
 }
 
 - (GBTemplateHandler *)htmlHierarchyTemplate {
-	return [self.templateFiles objectForKey:@"hierarchy-template.html"];
+	return self.templateFiles[@"hierarchy-template.html"];
 }
 
 - (GBTemplateHandler *)htmlDocumentTemplate {
-	return [self.templateFiles objectForKey:@"document-template.html"];
+	return self.templateFiles[@"document-template.html"];
 }
 
 #pragma mark Overriden methods

--- a/Generating/GBHTMLTemplateVariablesProvider.m
+++ b/Generating/GBHTMLTemplateVariablesProvider.m
@@ -107,76 +107,76 @@
 - (NSDictionary *)variablesForClass:(GBClassData *)object withStore:(id)aStore {
 	self.store = aStore;
 	NSMutableDictionary *page = [NSMutableDictionary dictionary];
-	[page setObject:[self pageTitleForClass:object] forKey:@"title"];
-	[page setObject:[self specificationsForClass:object] forKey:@"specifications"];
+	page[@"title"] = [self pageTitleForClass:object];
+	page[@"specifications"] = [self specificationsForClass:object];
 	[self addFooterVarsToDictionary:page];
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
-	[result setObject:page forKey:@"page"];
-	[result setObject:object forKey:@"object"];
-	[result setObject:self.settings.projectCompany forKey:@"projectCompany"];
-	[result setObject:self.settings.projectName forKey:@"projectName"];
-	[result setObject:self.settings.stringTemplates forKey:@"strings"];
+	result[@"page"] = page;
+	result[@"object"] = object;
+	result[@"projectCompany"] = self.settings.projectCompany;
+	result[@"projectName"] = self.settings.projectName;
+	result[@"strings"] = self.settings.stringTemplates;
 	return result;
 }
 
 - (NSDictionary *)variablesForCategory:(GBCategoryData *)object withStore:(id)aStore {
 	self.store = aStore;
 	NSMutableDictionary *page = [NSMutableDictionary dictionary];
-	[page setObject:[self pageTitleForCategory:object] forKey:@"title"];
-	[page setObject:[self specificationsForCategory:object] forKey:@"specifications"];
+	page[@"title"] = [self pageTitleForCategory:object];
+	page[@"specifications"] = [self specificationsForCategory:object];
 	[self addFooterVarsToDictionary:page];
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
-	[result setObject:page forKey:@"page"];
-	[result setObject:object forKey:@"object"];
-	[result setObject:self.settings.projectCompany forKey:@"projectCompany"];
-	[result setObject:self.settings.projectName forKey:@"projectName"];
+	result[@"page"] = page;
+	result[@"object"] = object;
+	result[@"projectCompany"] = self.settings.projectCompany;
+	result[@"projectName"] = self.settings.projectName;
 	
-	[result setObject:self.settings.stringTemplates forKey:@"strings"];
+	result[@"strings"] = self.settings.stringTemplates;
 	return result;
 }
 
 - (NSDictionary *)variablesForProtocol:(GBProtocolData *)object withStore:(id)aStore {
 	self.store = aStore;
 	NSMutableDictionary *page = [NSMutableDictionary dictionary];
-	[page setObject:[self pageTitleForProtocol:object] forKey:@"title"];
-	[page setObject:[self specificationsForProtocol:object] forKey:@"specifications"];
+	page[@"title"] = [self pageTitleForProtocol:object];
+	page[@"specifications"] = [self specificationsForProtocol:object];
 	[self addFooterVarsToDictionary:page];
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
-	[result setObject:page forKey:@"page"];
-	[result setObject:object forKey:@"object"];
-	[result setObject:self.settings.projectCompany forKey:@"projectCompany"];
-	[result setObject:self.settings.projectName forKey:@"projectName"];
-	[result setObject:self.settings.stringTemplates forKey:@"strings"];
+	result[@"page"] = page;
+	result[@"object"] = object;
+	result[@"projectCompany"] = self.settings.projectCompany;
+	result[@"projectName"] = self.settings.projectName;
+	result[@"strings"] = self.settings.stringTemplates;
 	return result;
 }
 
 - (NSDictionary *)variablesForConstant:(GBTypedefEnumData *)typedefEnum withStore:(id)aStore {
 	self.store = aStore;
 	NSMutableDictionary *page = [NSMutableDictionary dictionary];
-	[page setObject:[self pageTitleForConstant:typedefEnum] forKey:@"title"];
-	[page setObject:[self specificationsForConstant:typedefEnum] forKey:@"specifications"];
+	page[@"title"] = [self pageTitleForConstant:typedefEnum];
+	page[@"specifications"] = [self specificationsForConstant:typedefEnum];
 	[self addFooterVarsToDictionary:page];
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
-	[result setObject:page forKey:@"page"];
-	[result setObject:typedefEnum forKey:@"typedefEnum"];
-	[result setObject:self.settings.projectCompany forKey:@"projectCompany"];
-	[result setObject:self.settings.projectName forKey:@"projectName"];
-	[result setObject:self.settings.stringTemplates forKey:@"strings"];
+	result[@"page"] = page;
+	result[@"typedefEnum"] = typedefEnum;
+	result[@"projectCompany"] = self.settings.projectCompany;
+	result[@"projectName"] = self.settings.projectName;
+	result[@"strings"] = self.settings.stringTemplates;
 	return result;
 }
 
 - (NSDictionary *)variablesForBlocks:(GBTypedefBlockData *)typedefBlock withStore:(id)aStore {
     self.store = aStore;
     NSMutableDictionary *page = [NSMutableDictionary dictionary];
-    [page setObject:[self pageTitleForBlock:typedefBlock] forKey:@"title"];
-    [page setObject:[self specificationsForBlock:typedefBlock] forKey:@"specifications"];
+    page[@"title"] = [self pageTitleForBlock:typedefBlock];
+    page[@"specifications"] = [self specificationsForBlock:typedefBlock];
     [self addFooterVarsToDictionary:page];
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
-    [result setObject:page forKey:@"page"];
-    [result setObject:typedefBlock forKey:@"typedefBlock"];
-    [result setObject:self.settings.projectCompany forKey:@"projectCompany"];
-    [result setObject:self.settings.projectName forKey:@"projectName"];
-    [result setObject:self.settings.stringTemplates forKey:@"strings"];
+    result[@"page"] = page;
+    result[@"typedefBlock"] = typedefBlock;
+    result[@"projectCompany"] = self.settings.projectCompany;
+    result[@"projectName"] = self.settings.projectName;
+    result[@"strings"] = self.settings.stringTemplates;
     return result;
 }
 
@@ -185,18 +185,18 @@
 	self.store = aStore;
 	NSString *path = [self.settings htmlRelativePathToIndexFromObject:object];
 	NSMutableDictionary *page = [NSMutableDictionary dictionary];
-	[page setObject:[self pageTitleForDocument:object] forKey:@"title"];
-	[page setObject:[path stringByAppendingPathComponent:@"css/style.css"] forKey:@"cssPath"];
-	[page setObject:[path stringByAppendingPathComponent:@"css/stylePrint.css"] forKey:@"cssPrintPath"];
-	[page setObject:[path stringByAppendingPathComponent:@"js/script.js"] forKey:@"jsPath"];
-  [page setObject:[path stringByAppendingPathComponent:@"index.html"] forKey:@"documentationIndexPath"];
+	page[@"title"] = [self pageTitleForDocument:object];
+	page[@"cssPath"] = [path stringByAppendingPathComponent:@"css/style.css"];
+	page[@"cssPrintPath"] = [path stringByAppendingPathComponent:@"css/stylePrint.css"];
+	page[@"jsPath"] = [path stringByAppendingPathComponent:@"js/script.js"];
+  page[@"documentationIndexPath"] = [path stringByAppendingPathComponent:@"index.html"];
 	[self addFooterVarsToDictionary:page];
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
-	[result setObject:page forKey:@"page"];
-	[result setObject:object forKey:@"object"];
-	[result setObject:self.settings.projectCompany forKey:@"projectCompany"];
-	[result setObject:self.settings.projectName forKey:@"projectName"];
-	[result setObject:self.settings.stringTemplates forKey:@"strings"];
+	result[@"page"] = page;
+	result[@"object"] = object;
+	result[@"projectCompany"] = self.settings.projectCompany;
+	result[@"projectName"] = self.settings.projectName;
+	result[@"strings"] = self.settings.stringTemplates;
 	[self addFooterVarsToDictionary:result];
 	return result;
 }
@@ -206,20 +206,20 @@
 - (NSDictionary *)variablesForIndexWithStore:(id)aStore {
 	self.store = aStore;
 	NSMutableDictionary *page = [NSMutableDictionary dictionary];
-	[page setObject:[self pageTitleForIndex] forKey:@"title"];
-    [page setObject:[self docsSectionTitleForIndex] forKey:@"docsTitle"];
+	page[@"title"] = [self pageTitleForIndex];
+    page[@"docsTitle"] = [self docsSectionTitleForIndex];
 	[self addFooterVarsToDictionary:page];
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
-	[result setObject:page forKey:@"page"];
-	[result setObject:[self documentsForIndex] forKey:@"docs"];
-	[result setObject:[self classesForIndex] forKey:@"classes"];
-	[result setObject:[self protocolsForIndex] forKey:@"protocols"];
-	[result setObject:[self categoriesForIndex] forKey:@"categories"];
-    [result setObject:[self constantsForIndex]  forKey:@"constants"];
-    [result setObject:[self blocksForIndex]  forKey:@"blocks"];
-	[result setObject:self.settings.stringTemplates forKey:@"strings"];
-	[result setObject:self.settings.projectCompany forKey:@"projectCompany"];
-	[result setObject:self.settings.projectName forKey:@"projectName"];
+	result[@"page"] = page;
+	result[@"docs"] = [self documentsForIndex];
+	result[@"classes"] = [self classesForIndex];
+	result[@"protocols"] = [self protocolsForIndex];
+	result[@"categories"] = [self categoriesForIndex];
+    result[@"constants"] = [self constantsForIndex];
+    result[@"blocks"] = [self blocksForIndex];
+	result[@"strings"] = self.settings.stringTemplates;
+	result[@"projectCompany"] = self.settings.projectCompany;
+	result[@"projectName"] = self.settings.projectName;
 	
 	[self addCustomDocumentWithKey:kGBCustomDocumentIndexDescKey toDictionary:result key:@"indexDescription"];
 	[self registerObjectsUsageForIndexInDictionary:result];
@@ -229,18 +229,18 @@
 - (NSDictionary *)variablesForHierarchyWithStore:(id)aStore {
 	self.store = aStore;
 	NSMutableDictionary *page = [NSMutableDictionary dictionary];
-	[page setObject:[self pageTitleForHierarchy] forKey:@"title"];
+	page[@"title"] = [self pageTitleForHierarchy];
 	[self addFooterVarsToDictionary:page];
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
-	[result setObject:page forKey:@"page"];
-	[result setObject:[self classesForHierarchy] forKey:@"classes"];
-	[result setObject:[self protocolsForIndex] forKey:@"protocols"];
-	[result setObject:[self categoriesForIndex] forKey:@"categories"];
-	[result setObject:[self constantsForIndex] forKey:@"constants"];
-    [result setObject:[self blocksForIndex] forKey:@"blocks"];
-    [result setObject:self.settings.stringTemplates forKey:@"strings"];
-	[result setObject:self.settings.projectCompany forKey:@"projectCompany"];
-	[result setObject:self.settings.projectName forKey:@"projectName"];
+	result[@"page"] = page;
+	result[@"classes"] = [self classesForHierarchy];
+	result[@"protocols"] = [self protocolsForIndex];
+	result[@"categories"] = [self categoriesForIndex];
+	result[@"constants"] = [self constantsForIndex];
+    result[@"blocks"] = [self blocksForIndex];
+    result[@"strings"] = self.settings.stringTemplates;
+	result[@"projectCompany"] = self.settings.projectCompany;
+	result[@"projectName"] = self.settings.projectName;
 	
 	[self registerObjectsUsageForIndexInDictionary:result];
 	return result;
@@ -263,11 +263,11 @@
 	// Helps handling arrays in template by embedding two keys: "used" as boolean and "items" as the actual array (only if non-empty).
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
 	if ([array count] > 0) {
-		[result setObject:[NSNumber numberWithBool:YES] forKey:@"used"];
-		[result setObject:array forKey:@"values"];
+		result[@"used"] = @YES;
+		result[@"values"] = array;
 		return result;
 	}
-	[result setObject:[NSNumber numberWithBool:NO] forKey:@"used"];
+	result[@"used"] = @NO;
 	return result;
 }
 
@@ -277,7 +277,7 @@
 	// Adds custom document with the given key to the given dictionary using the given dictionary key. If custom document isn't found, nothing happens.
 	GBDocumentData *document = [self.store customDocumentWithKey:key];
 	if (!document) return;
-	[dict setObject:document forKey:dictKey];
+	dict[dictKey] = document;
 }
 
 - (void)addFooterVarsToDictionary:(NSMutableDictionary *)dict {
@@ -286,9 +286,9 @@
     {
         projectCompanyForFooter = [projectCompanyForFooter substringToIndex:projectCompanyForFooter.length - 1];
     }
-	[dict setObject:projectCompanyForFooter forKey:@"copyrightHolder"];
-	[dict setObject:[self.settings stringByReplacingOccurencesOfPlaceholdersInString:kGBTemplatePlaceholderYear] forKey:@"copyrightDate"];
-	[dict setObject:[self.settings stringByReplacingOccurencesOfPlaceholdersInString:kGBTemplatePlaceholderUpdateDate] forKey:@"lastUpdatedDate"];
+	dict[@"copyrightHolder"] = projectCompanyForFooter;
+	dict[@"copyrightDate"] = [self.settings stringByReplacingOccurencesOfPlaceholdersInString:kGBTemplatePlaceholderYear];
+	dict[@"lastUpdatedDate"] = [self.settings stringByReplacingOccurencesOfPlaceholdersInString:kGBTemplatePlaceholderUpdateDate];
 }
 
 #pragma mark Properties
@@ -487,8 +487,8 @@
 		if ([item.relatedItem isStaticDocument]) {
 			NSArray *components = [item.markdownValue captureComponentsMatchedByRegex:self.settings.commentComponents.markdownInlineLinkRegex];
 			if ([components count] > 0) {
-				NSString *name = [components objectAtIndex:1];
-				NSString *href = [components objectAtIndex:2];
+				NSString *name = components[1];
+				NSString *href = components[2];
 				NSDictionary *data = [self objectSpecificationValueWithData:name href:href];
 				[relatedDocuments addObject:data];
 			}
@@ -506,24 +506,24 @@
 - (NSDictionary *)objectSpecificationWithValues:(NSArray *)values title:(NSString *)title {
 	// Prepares inherits from specification variable with the given array of superclass hierarchy values.
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
-	[result setObject:title forKey:@"title"];
-	[result setObject:values forKey:@"values"];
+	result[@"title"] = title;
+	result[@"values"] = values;
 	return result;
 }
 
 - (NSDictionary *)objectSpecificationValueWithData:(id)data href:(NSString *)href {
 	// Prepares single specification value.
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
-	if (href) [result setObject:href forKey:@"href"];
-	[result setObject:data forKey:@"string"];
-	[result setObject:@"" forKey:@"delimiter"];
+	if (href) result[@"href"] = href;
+	result[@"string"] = data;
+	result[@"delimiter"] = @"";
 	return result;
 }
 
 - (NSArray *)delimitObjectSpecificationValues:(NSArray *)values withDelimiter:(NSString *)delimiter {
 	// The array should contain mutable dictionaries with keys "data" and "href". We simplt add the delimiter to all but last value and use it to prepare the resulting specification dictionary containing all values.
 	[values enumerateObjectsUsingBlock:^(NSMutableDictionary *data, NSUInteger idx, BOOL *stop) {
-		if (idx < [values count] - 1) [data setObject:delimiter forKey:@"delimiter"];
+		if (idx < [values count] - 1) data[@"delimiter"] = delimiter;
 	}];
 	return values;
 }
@@ -535,12 +535,12 @@
 @implementation GBHTMLTemplateVariablesProvider (IndexVariables)
 
 - (NSString *)pageTitleForIndex {
-	NSString *template = [self.settings.stringTemplates.indexPage objectForKey:@"titleTemplate"];
+	NSString *template = self.settings.stringTemplates.indexPage[@"titleTemplate"];
 	return [NSString stringWithFormat:template, self.settings.projectName];
 }
 
 - (NSString *)pageTitleForHierarchy {
-	NSString *template = [self.settings.stringTemplates.hierarchyPage objectForKey:@"titleTemplate"];
+	NSString *template = self.settings.stringTemplates.hierarchyPage[@"titleTemplate"];
 	return [NSString stringWithFormat:template, self.settings.projectName];
 }
 
@@ -550,7 +550,7 @@
         return self.settings.docsSectionTitle;
     }
     
-    return [self.settings.stringTemplates.indexPage objectForKey:@"docsTitle"];
+    return self.settings.stringTemplates.indexPage[@"docsTitle"];
 }
 
 - (NSArray*)documentsForIndex{
@@ -558,8 +558,8 @@
 	NSMutableArray *result = [NSMutableArray arrayWithCapacity:[documents count]];
 	for (GBDocumentData *document in documents) {
 		NSMutableDictionary *data = [NSMutableDictionary dictionaryWithCapacity:2];
-		[data setObject:[self hrefForObject:document fromObject:nil] forKey:@"href"];
-		[data setObject:document.prettyNameOfDocument forKey:@"title"];
+		data[@"href"] = [self hrefForObject:document fromObject:nil];
+		data[@"title"] = document.prettyNameOfDocument;
 		[result addObject:data];
 	}
 	return result;
@@ -571,8 +571,8 @@
 	for (GBClassData *class in classes) {
         if (!class.includeInOutput) continue;
 		NSMutableDictionary *data = [NSMutableDictionary dictionaryWithCapacity:2];
-		[data setObject:[self hrefForObject:class fromObject:nil] forKey:@"href"];
-		[data setObject:class.nameOfClass forKey:@"title"];
+		data[@"href"] = [self hrefForObject:class fromObject:nil];
+		data[@"title"] = class.nameOfClass;
 		[result addObject:data];
 	}
 	return result;
@@ -584,8 +584,8 @@
 	for (GBCategoryData *category in categories) {
         if (!category.includeInOutput) continue;
 		NSMutableDictionary *data = [NSMutableDictionary dictionaryWithCapacity:2];
-		[data setObject:[self hrefForObject:category fromObject:nil] forKey:@"href"];
-		[data setObject:category.idOfCategory forKey:@"title"];
+		data[@"href"] = [self hrefForObject:category fromObject:nil];
+		data[@"title"] = category.idOfCategory;
 		[result addObject:data];
 	}
 	return result;
@@ -597,8 +597,8 @@
 	for (GBTypedefEnumData *constant in constants) {
         if (!constant.includeInOutput) continue;
 		NSMutableDictionary *data = [NSMutableDictionary dictionaryWithCapacity:2];
-		[data setObject:[self hrefForObject:constant fromObject:nil] forKey:@"href"];
-		[data setObject:constant.nameOfEnum forKey:@"title"];
+		data[@"href"] = [self hrefForObject:constant fromObject:nil];
+		data[@"title"] = constant.nameOfEnum;
 		[result addObject:data];
 	}
 	return result;
@@ -610,8 +610,8 @@
     for (GBTypedefBlockData *block in blocks) {
         if (!block.includeInOutput) continue;
         NSMutableDictionary *data = [NSMutableDictionary dictionaryWithCapacity:2];
-        [data setObject:[self hrefForObject:block fromObject:nil] forKey:@"href"];
-        [data setObject:block.nameOfBlock forKey:@"title"];
+        data[@"href"] = [self hrefForObject:block fromObject:nil];
+        data[@"title"] = block.nameOfBlock;
         [result addObject:data];
     }
     return result;
@@ -623,8 +623,8 @@
 	for (GBProtocolData *protocol in protocols) {
         if (!protocol.includeInOutput) continue;
 		NSMutableDictionary *data = [NSMutableDictionary dictionaryWithCapacity:2];
-		[data setObject:[self hrefForObject:protocol fromObject:nil] forKey:@"href"];
-		[data setObject:protocol.nameOfProtocol forKey:@"title"];
+		data[@"href"] = [self hrefForObject:protocol fromObject:nil];
+		data[@"title"] = protocol.nameOfProtocol;
 		[result addObject:data];
 	}
 	return result;
@@ -647,14 +647,14 @@
 		// Now traverse the flat list and add all unknown classes to the dictionary. Then add all subclasses to next level and update the data we'll be matching in the next iteration (i.e. subclasses). This way we always start with the root dictionary and progress the depth on each iteration.
 		NSMutableDictionary *currentLevel = hierarchy;
 		for (NSString *className in flatlist) {
-			NSMutableDictionary *classData = [currentLevel objectForKey:className];
+			NSMutableDictionary *classData = currentLevel[className];
 			if (!classData) {
 				classData = [NSMutableDictionary dictionary];
-				[classData setObject:className forKey:@"name"];
-				[classData setObject:[NSMutableDictionary dictionary] forKey:@"subclasses"];
-				[currentLevel setObject:classData forKey:className];
+				classData[@"name"] = className;
+				classData[@"subclasses"] = [NSMutableDictionary dictionary];
+				currentLevel[className] = classData;
 			}
-			currentLevel = [classData objectForKey:@"subclasses"];
+			currentLevel = classData[@"subclasses"];
 		}
 	}
 	
@@ -667,7 +667,7 @@
 	NSMutableArray *result = [NSMutableArray arrayWithCapacity:[level count]];
 	[level enumerateKeysAndObjectsUsingBlock:^(NSString *name, NSDictionary *data, BOOL *stop) {
 		// Get all sublasses by recursively descending down the hierarchy.
-		NSArray *subclasses = [self arrayFromHierarchyLevel:[data objectForKey:@"subclasses"]];
+		NSArray *subclasses = [self arrayFromHierarchyLevel:data[@"subclasses"]];
 		
 		// Get current class from the store and href to it.
 		GBClassData *class = [self.store classWithName:name];
@@ -675,15 +675,15 @@
 		
 		// Prepare class data.
 		NSMutableDictionary *classData = [NSMutableDictionary dictionary];
-		[classData setObject:name forKey:@"name"];
-		[classData setObject:subclasses forKey:@"classes"];
-		[classData setObject:[NSNumber numberWithBool:([subclasses count] > 0)] forKey:@"hasClasses"];
-		if (href) [classData setObject:href forKey:@"href"];
+		classData[@"name"] = name;
+		classData[@"classes"] = subclasses;
+		classData[@"hasClasses"] = @([subclasses count] > 0);
+		if (href) classData[@"href"] = href;
 		[result addObject:classData];
 	}];
 	
 	// Sort the array by class names.
-	NSArray *descriptors = [NSArray arrayWithObject:[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES]];
+	NSArray *descriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES]];
 	return [result sortedArrayUsingDescriptors:descriptors];
 }
 
@@ -694,13 +694,13 @@
 	BOOL protocols = [self.store.protocols count] > 0;
     BOOL constants = [self.store.constants count] > 0;
     BOOL blocks = [self.store.blocks count] > 0;
-    [dict setObject:[NSNumber numberWithBool:documents] forKey:@"hasDocs"];
-    [dict setObject:[NSNumber numberWithBool:classes] forKey:@"hasClasses"];
-	[dict setObject:[NSNumber numberWithBool:categories] forKey:@"hasCategories"];
-	[dict setObject:[NSNumber numberWithBool:protocols] forKey:@"hasProtocols"];
-	[dict setObject:[NSNumber numberWithBool:constants] forKey:@"hasConstants"];
-    [dict setObject:[NSNumber numberWithBool:blocks] forKey:@"hasBlocks"];
-	[dict setObject:[NSNumber numberWithBool:protocols || categories || constants || blocks] forKey:@"hasProtocolsOrCategories"];
+    dict[@"hasDocs"] = @(documents);
+    dict[@"hasClasses"] = @(classes);
+	dict[@"hasCategories"] = @(categories);
+	dict[@"hasProtocols"] = @(protocols);
+	dict[@"hasConstants"] = @(constants);
+    dict[@"hasBlocks"] = @(blocks);
+	dict[@"hasProtocolsOrCategories"] = @(protocols || categories || constants || blocks);
 }
 
 @end

--- a/Generating/GBTemplateFilesHandler.m
+++ b/Generating/GBTemplateFilesHandler.m
@@ -89,7 +89,7 @@
 			GBTemplateHandler *handler = [self templateHandlerFromTemplateFile:path error:error];
 			if (!handler) return NO;
 			GBLogDebug(@"Removing template file '%@' from output...", path);
-			[self.templateFiles setObject:handler forKey:path];
+			self.templateFiles[path] = handler;
 			delete = YES;
 		}
 		
@@ -135,14 +135,12 @@
 
 - (BOOL)isPathRepresentingTemplateFile:(NSString *)path {
 	NSString *filename = [[path lastPathComponent] stringByDeletingPathExtension];
-	if ([filename hasSuffix:@"-template"]) return YES;
-	return NO;
+	return [filename hasSuffix:@"-template"];
 }
 
 - (BOOL)isPathRepresentingIgnoredFile:(NSString *)path {
 	NSString *filename = [path lastPathComponent];
-	if ([filename hasPrefix:@"."]) return YES;
-	return NO;
+	return [filename hasPrefix:@"."];
 }
 
 #pragma mark Properties

--- a/Generating/GBTemplateHandler.m
+++ b/Generating/GBTemplateHandler.m
@@ -72,17 +72,17 @@ static NSString *kGBValueKey = @"value";
 
 		// If section data is valid, use it.
 		if ([self validateSectionData:sectionData withTemplate:template]) {
-			NSString *name = [sectionData objectForKey:kGBNameKey];
-			NSString *value = [[sectionData objectForKey:kGBValueKey] stringByTrimmingWhitespaceAndNewLine];
-			[_templateSections setObject:value forKey:name];
+			NSString *name = sectionData[kGBNameKey];
+			NSString *value = [sectionData[kGBValueKey] stringByTrimmingWhitespaceAndNewLine];
+			_templateSections[name] = value;
 		}
 		
 		// If the section is valid, log it.
 		NSUInteger line = [self lineOfSectionData:sectionData withinTemplate:template];
-		GBLogDebug(@"Found section template %@ at line %ld...", [sectionData objectForKey:kGBNameKey], line);
+		GBLogDebug(@"Found section template %@ at line %ld...", sectionData[kGBNameKey], line);
 
 		// Get the range of the regex within the clean string and remove the substring from it.
-		NSString *section = [sectionData objectForKey:kGBSectionKey];
+		NSString *section = sectionData[kGBSectionKey];
 		NSRange range = [clean rangeOfString:section];
 		NSString *prefix = [[clean substringToIndex:range.location] stringByTrimmingWhitespaceAndNewLine];
 		NSString *suffix = [[clean substringFromIndex:range.location + range.length] stringByTrimmingWhitespaceAndNewLine];
@@ -124,14 +124,14 @@ static NSString *kGBValueKey = @"value";
 #pragma mark Helper methods
 
 - (BOOL)validateSectionData:(NSDictionary *)data withTemplate:(NSString *)template {
-	NSString *name = [data objectForKey:kGBNameKey];
+	NSString *name = data[kGBNameKey];
 	if ([name length] == 0) {
 		NSUInteger line = [self lineOfSectionData:data withinTemplate:template];
 		GBLogWarn(@"Unnamed section found at line %ld, ignoring!", line);
 		return NO;
 	}
 
-	NSString *value = [[data objectForKey:kGBValueKey] stringByTrimmingWhitespace];
+	NSString *value = [data[kGBValueKey] stringByTrimmingWhitespace];
 	if ([value length] == 0) {
 		NSUInteger line = [self lineOfSectionData:data withinTemplate:template];
 		GBLogWarn(@"Empty section %@ found at line %ld, ignoring!", name, line);
@@ -142,7 +142,7 @@ static NSString *kGBValueKey = @"value";
 }
 
 - (NSUInteger)lineOfSectionData:(NSDictionary *)data withinTemplate:(NSString *)template {
-	NSString *section = [data objectForKey:kGBSectionKey];
+	NSString *section = data[kGBSectionKey];
 	NSRange range = [template rangeOfString:section];
 	return [template numberOfLinesInRange:NSMakeRange(0, range.location)];
 }

--- a/Model/GBAdoptedProtocolsProvider.m
+++ b/Model/GBAdoptedProtocolsProvider.m
@@ -36,22 +36,22 @@
 	NSParameterAssert(protocol != nil);
 	GBLogDebug(@"%@: Registering protocol %@...", _parent, protocol);
 	if ([_protocols containsObject:protocol]) return;
-	GBProtocolData *existingProtocol = [_protocolsByName objectForKey:protocol.nameOfProtocol];
+	GBProtocolData *existingProtocol = _protocolsByName[protocol.nameOfProtocol];
 	if (existingProtocol) {
 		[existingProtocol mergeDataFromObject:protocol];
 		return;
 	}
-	if ([_protocolsByName objectForKey:protocol.nameOfProtocol]) 
+	if (_protocolsByName[protocol.nameOfProtocol])
 		[NSException raise:@"Protocol with name %@ is already registered!", protocol.nameOfProtocol];
 	[_protocols addObject:protocol];
-	[_protocolsByName setObject:protocol forKey:protocol.nameOfProtocol];
+	_protocolsByName[protocol.nameOfProtocol] = protocol;
 }
 
 - (void)mergeDataFromProtocolsProvider:(GBAdoptedProtocolsProvider *)source {
 	if (!source || source == self) return;
 	GBLogDebug(@"%@: Merging adopted protocols from %@...", _parent, source->_parent);
 	for (GBProtocolData *sourceProtocol in source.protocols) {
-		GBProtocolData *existingProtocol = [_protocolsByName objectForKey:sourceProtocol.nameOfProtocol];
+		GBProtocolData *existingProtocol = _protocolsByName[sourceProtocol.nameOfProtocol];
 		if (existingProtocol) {
 			[existingProtocol mergeDataFromObject:sourceProtocol];
 			continue;
@@ -68,7 +68,7 @@
 }
 
 - (NSArray *)protocolsSortedByName {
-	NSArray *descriptors = [NSArray arrayWithObject:[NSSortDescriptor sortDescriptorWithKey:@"protocolName" ascending:YES]];
+	NSArray *descriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"protocolName" ascending:YES]];
 	return [[self.protocols allObjects] sortedArrayUsingDescriptors:descriptors];
 }
 

--- a/Model/GBIvarsProvider.m
+++ b/Model/GBIvarsProvider.m
@@ -31,21 +31,21 @@
 	NSParameterAssert(ivar != nil);
 	GBLogDebug(@"%@: Registering ivar %@...", _parent, ivar);
 	if ([_ivars containsObject:ivar]) return;
-	GBIvarData *existingIvar = [_ivarsByName objectForKey:ivar.nameOfIvar];
+	GBIvarData *existingIvar = _ivarsByName[ivar.nameOfIvar];
 	if (existingIvar) {
 		[existingIvar mergeDataFromObject:ivar];
 		return;
 	}
 	ivar.parentObject = _parent;
 	[_ivars addObject:ivar];
-	[_ivarsByName setObject:ivar forKey:ivar.nameOfIvar];
+	_ivarsByName[ivar.nameOfIvar] = ivar;
 }
 
 - (void)mergeDataFromIvarsProvider:(GBIvarsProvider *)source {
 	if (!source || source == self) return;
 	GBLogDebug(@"%@: Merging ivars from %@...", _parent, source->_parent);
 	for (GBIvarData *sourceIvar in source.ivars) {
-		GBIvarData *existingIvar = [_ivarsByName objectForKey:sourceIvar.nameOfIvar];
+		GBIvarData *existingIvar = _ivarsByName[sourceIvar.nameOfIvar];
 		if (existingIvar) {
 			[existingIvar mergeDataFromObject:sourceIvar];
 			continue;

--- a/Model/GBMethodArgument.m
+++ b/Model/GBMethodArgument.m
@@ -26,7 +26,7 @@
 
 - (id)initWithName:(NSString *)name types:(NSArray *)types var:(NSString *)var variableArg:(BOOL)variableArg terminationMacros:(NSArray *)macros {
 	NSParameterAssert(name != nil);
-	if ([types count] == 0 && var != nil) types = [NSArray arrayWithObject:@"id"];
+	if ([types count] == 0 && var != nil) types = @[@"id"];
 	self = [super init];
 	if (self) {
 		_argumentName = [name copy];

--- a/Model/GBMethodData.m
+++ b/Model/GBMethodData.m
@@ -108,7 +108,7 @@
 	if ([results containsObject:propertyName]) [results removeObject:propertyName];
     
 	GBMethodArgument *argument = [GBMethodArgument methodArgumentWithName:propertyName];
-	return [[self alloc] initWithType:GBMethodTypeProperty attributes:attributes result:results arguments:[NSArray arrayWithObject:argument]];
+	return [[self alloc] initWithType:GBMethodTypeProperty attributes:attributes result:results arguments:@[argument]];
 }
 
 - (id)initWithType:(GBMethodType)type attributes:(NSArray *)attributes result:(NSArray *)result arguments:(NSArray *)arguments {
@@ -217,7 +217,7 @@
 		if (isLast || isPointer) appendSpace = NO;
 		
 		// We should not add space between components of a protocol (i.e. id<ProtocolName> should be written without any space). Because we've alreay
-		if (!isLast && idx+1 < [types count] && [[types objectAtIndex:idx+1] isEqualToString:@"<"])
+		if (!isLast && idx+1 < [types count] && [types[idx + 1] isEqualToString:@"<"])
 			insideProtocol = YES;
 		else if ([type isEqualToString:@">"])
 			insideProtocol = NO;
@@ -258,12 +258,12 @@
 
 - (NSDictionary *)formattedComponentWithValue:(NSString *)value style:(NSUInteger)style href:(NSString *)href {
 	NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:3];
-	[result setObject:value forKey:@"value"];
+	result[@"value"] = value;
 	if (style > 0) {
-		[result setObject:[NSNumber numberWithUnsignedInt:style] forKey:@"style"];
-		[result setObject:[NSNumber numberWithBool:YES] forKey:@"emphasized"];
+		result[@"style"] = [NSNumber numberWithUnsignedInt:style];
+		result[@"emphasized"] = @YES;
 	}
-	if (href) [result setObject:href forKey:@"href"];
+	if (href) result[@"href"] = href;
 	return result;
 }
 
@@ -385,8 +385,8 @@
 	if ([source comment] && ![self comment]) {
 		GBLogDebug(@"%@: Checking for difference due to comment status...", self);
 		for (NSUInteger i=0; i<[self.methodArguments count]; i++) {
-			GBMethodArgument *ourArgument = [[self methodArguments] objectAtIndex:i];
-			GBMethodArgument *otherArgument = [[source methodArguments] objectAtIndex:i];
+			GBMethodArgument *ourArgument = [self methodArguments][i];
+			GBMethodArgument *otherArgument = [source methodArguments][i];
 			if (![ourArgument.argumentVar isEqualToString:otherArgument.argumentVar]) {
 				GBLogDebug(@"%@: Changing %ld. argument var name from %@ to %@...", self, i+1, ourArgument.argumentVar, otherArgument.argumentVar);
 				ourArgument.argumentVar = otherArgument.argumentVar;

--- a/Model/GBModelBase.m
+++ b/Model/GBModelBase.m
@@ -32,16 +32,16 @@
 	// Merge declared files.
 	NSArray *sourceFiles = [[source sourceInfos] allObjects];
 	for (GBSourceInfo *filedata in sourceFiles) {
-		GBSourceInfo *ourfiledata = [_sourceInfosByFilenames objectForKey:filedata.filename];
+		GBSourceInfo *ourfiledata = _sourceInfosByFilenames[filedata.filename];
 		if (ourfiledata) {
 			if (ourfiledata.lineNumber < filedata.lineNumber) {
-				[_sourceInfosByFilenames setObject:filedata forKey:filedata.filename];
+				_sourceInfosByFilenames[filedata.filename] = filedata;
 				[_sourceInfos removeObject:ourfiledata];
 				[_sourceInfos addObject:filedata];
 			}
 			continue;
 		}
-		[_sourceInfosByFilenames setObject:filedata forKey:filedata.filename];
+		_sourceInfosByFilenames[filedata.filename] = filedata;
 		[_sourceInfos addObject:filedata];
 	}
 	
@@ -63,11 +63,11 @@
 	if ([_sourceInfos member:data]) return;
 	
 	// Replace data with same filename.
-	GBSourceInfo *existing = [_sourceInfosByFilenames objectForKey:data.filename];
+	GBSourceInfo *existing = _sourceInfosByFilenames[data.filename];
 	if (existing) [_sourceInfos removeObject:existing];
 	
 	// Add object.
-	[_sourceInfosByFilenames setObject:data forKey:data.filename];
+	_sourceInfosByFilenames[data.filename] = data;
 	[_sourceInfos addObject:data];
 }
 
@@ -78,7 +78,7 @@
 		for (GBSourceInfo *info in infos) {
 			if ([[info.filename pathExtension] isEqualToString:@"h"]) return info;
 		}
-		return [infos objectAtIndex:0];
+		return infos[0];
 	}
 	return nil;
 }

--- a/Model/GBStore.m
+++ b/Model/GBStore.m
@@ -46,23 +46,23 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBStore, sharedStore);
 #pragma mark Helper methods
 
 - (NSArray *)documentsSortedByName{
-	NSArray *descriptors = [NSArray arrayWithObject:[NSSortDescriptor sortDescriptorWithKey:@"prettyNameOfDocument" ascending:YES]];
+	NSArray *descriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"prettyNameOfDocument" ascending:YES]];
 	return [[self.documents allObjects] sortedArrayUsingDescriptors:descriptors];
 }
 
 - (NSArray *)classesSortedByName {
-	NSArray *descriptors = [NSArray arrayWithObject:[NSSortDescriptor sortDescriptorWithKey:@"nameOfClass" ascending:YES]];
+	NSArray *descriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"nameOfClass" ascending:YES]];
 	return [[self.classes allObjects] sortedArrayUsingDescriptors:descriptors];
 }
 
 
 - (NSArray *)constantsSortedByName {
-	NSArray *descriptors = [NSArray arrayWithObject:[NSSortDescriptor sortDescriptorWithKey:@"nameOfEnum" ascending:YES]];
+	NSArray *descriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"nameOfEnum" ascending:YES]];
 	return [[self.constants allObjects] sortedArrayUsingDescriptors:descriptors];
 }
 
 - (NSArray *)blocksSortedByName {
-    NSArray *descriptors = [NSArray arrayWithObject:[NSSortDescriptor sortDescriptorWithKey:@"nameOfBlock" ascending:YES]];
+    NSArray *descriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"nameOfBlock" ascending:YES]];
     return [[self.blocks allObjects] sortedArrayUsingDescriptors:descriptors];
 }
 
@@ -70,12 +70,12 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBStore, sharedStore);
 - (NSArray *)categoriesSortedByName {
 	NSSortDescriptor *classNameDescription = [NSSortDescriptor sortDescriptorWithKey:@"nameOfClass" ascending:YES];
 	NSSortDescriptor *categoryNameDescription = [NSSortDescriptor sortDescriptorWithKey:@"categoryName" ascending:YES];
-	NSArray *descriptors = [NSArray arrayWithObjects:classNameDescription, categoryNameDescription, nil];
+	NSArray *descriptors = @[classNameDescription, categoryNameDescription];
 	return [[self.categories allObjects] sortedArrayUsingDescriptors:descriptors];
 }
 
 - (NSArray *)protocolsSortedByName {
-	NSArray *descriptors = [NSArray arrayWithObject:[NSSortDescriptor sortDescriptorWithKey:@"protocolName" ascending:YES]];
+	NSArray *descriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"protocolName" ascending:YES]];
 	return [[self.protocols allObjects] sortedArrayUsingDescriptors:descriptors];
 }
 
@@ -85,13 +85,13 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBStore, sharedStore);
 	NSParameterAssert(class != nil);
 	GBLogDebug(@"Registering class %@...", class);
 	if ([_classes containsObject:class]) return;
-	GBClassData *existingClass = [_classesByName objectForKey:class.nameOfClass];
+	GBClassData *existingClass = _classesByName[class.nameOfClass];
 	if (existingClass) {
 		[existingClass mergeDataFromObject:class];
 		return;
 	}
 	[_classes addObject:class];
-	[_classesByName setObject:class forKey:class.nameOfClass];
+	_classesByName[class.nameOfClass] = class;
 }
 
 - (void)registerCategory:(GBCategoryData *)category {
@@ -99,26 +99,26 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBStore, sharedStore);
 	GBLogDebug(@"Registering category %@...", category);
 	if ([_categories containsObject:category]) return;
 	NSString *categoryID = [NSString stringWithFormat:@"%@(%@)", category.nameOfClass, category.nameOfCategory ? category.nameOfCategory : @""];
-	GBCategoryData *existingCategory = [_categoriesByName objectForKey:categoryID];
+	GBCategoryData *existingCategory = _categoriesByName[categoryID];
 	if (existingCategory) {
 		[existingCategory mergeDataFromObject:category];
 		return;
 	}
 	[_categories addObject:category];
-	[_categoriesByName setObject:category forKey:categoryID];
+	_categoriesByName[categoryID] = category;
 }
 
 - (void)registerProtocol:(GBProtocolData *)protocol {
 	NSParameterAssert(protocol != nil);
 	GBLogDebug(@"Registering class %@...", protocol);
 	if ([_protocols containsObject:protocol]) return;
-	GBProtocolData *existingProtocol = [_protocolsByName objectForKey:protocol.nameOfProtocol];
+	GBProtocolData *existingProtocol = _protocolsByName[protocol.nameOfProtocol];
 	if (existingProtocol) {
 		[existingProtocol mergeDataFromObject:protocol];
 		return;
 	}
 	[_protocols addObject:protocol];
-	[_protocolsByName setObject:protocol forKey:protocol.nameOfProtocol];
+	_protocolsByName[protocol.nameOfProtocol] = protocol;
 }
 
 -(void)registerTypedefEnum:(GBTypedefEnumData *)typedefEnum
@@ -126,14 +126,14 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBStore, sharedStore);
     NSParameterAssert(typedefEnum != nil);
 	GBLogDebug(@"Registering typedef enum %@...", typedefEnum);
 	if ([_typedefEnums containsObject:typedefEnum]) return;
-	GBProtocolData *existingTypedef = [_typedefEnumsByName objectForKey:typedefEnum.nameOfEnum];
+	GBProtocolData *existingTypedef = _typedefEnumsByName[typedefEnum.nameOfEnum];
 	if (existingTypedef) {
         GBLogWarn(@"Ignoring typedef enum %@, already defined.", typedefEnum);
         return;
     }
 
 	[_typedefEnums addObject:typedefEnum];
-	[_typedefEnumsByName setObject:typedefEnum forKey:typedefEnum.nameOfEnum];
+	_typedefEnumsByName[typedefEnum.nameOfEnum] = typedefEnum;
 }
 
 -(void)registerTypedefBlock:(GBTypedefBlockData *)typedefBlock
@@ -141,14 +141,14 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBStore, sharedStore);
     NSParameterAssert(typedefBlock != nil);
     GBLogDebug(@"Registering typedef block %@...", typedefBlock);
     if ([_typedefBlocks containsObject:typedefBlock]) return;
-    GBProtocolData *existingTypedef = [_typedefBlocksByName objectForKey:typedefBlock.nameOfBlock];
+    GBProtocolData *existingTypedef = _typedefBlocksByName[typedefBlock.nameOfBlock];
     if (existingTypedef) {
         GBLogWarn(@"Ignoring typedef block %@, already defined.", typedefBlock);
         return;
     }
     
     [_typedefBlocks addObject:typedefBlock];
-    [_typedefBlocksByName setObject:typedefBlock forKey:typedefBlock.nameOfBlock];
+    _typedefBlocksByName[typedefBlock.nameOfBlock] = typedefBlock;
 }
 
 
@@ -157,22 +157,22 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBStore, sharedStore);
 	GBLogDebug(@"Registering document %@...", document);
 	if ([_documents containsObject:document]) return;
 	NSString *name = [document.nameOfDocument stringByDeletingPathExtension];
-	GBDocumentData *existingDocument = [_documentsByName objectForKey:name];
+	GBDocumentData *existingDocument = _documentsByName[name];
     if (existingDocument) {
         GBLogWarn(@"Ignoring document %@, already defined.", document);
         return;
     }
 
 	[_documents addObject:document];
-	[_documentsByName setObject:document forKey:name];
-	[_documentsByName setObject:document forKey:[name stringByReplacingOccurrencesOfString:@"-template" withString:@""]];
+	_documentsByName[name] = document;
+	_documentsByName[[name stringByReplacingOccurrencesOfString:@"-template" withString:@""]] = document;
 }
 
 - (void)registerCustomDocument:(GBDocumentData *)document withKey:(id)key {
 	NSParameterAssert(document != nil);
 	GBLogDebug(@"Registering custom document %@...", document);
 	[_customDocuments addObject:document];
-	[_customDocumentsByKey setObject:document forKey:key];
+	_customDocumentsByKey[key] = document;
 }
 
 - (void)unregisterTopLevelObject:(id)object {
@@ -196,31 +196,31 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBStore, sharedStore);
 #pragma mark Data providing
 
 - (GBClassData *)classWithName:(NSString *)name {
-	return [_classesByName objectForKey:name];
+	return _classesByName[name];
 }
 
 - (GBCategoryData *)categoryWithName:(NSString *)name {
-	return [_categoriesByName objectForKey:name];
+	return _categoriesByName[name];
 }
 
 - (GBProtocolData *)protocolWithName:(NSString *)name {
-	return [_protocolsByName objectForKey:name];
+	return _protocolsByName[name];
 }
 
 - (GBDocumentData *)documentWithName:(NSString *)path {
-	return [_documentsByName objectForKey:path];
+	return _documentsByName[path];
 }
 
 - (GBTypedefEnumData *)typedefEnumWithName:(NSString *)path {
-	return [_typedefEnumsByName objectForKey:path];
+	return _typedefEnumsByName[path];
 }
 
 - (GBTypedefBlockData *)typedefBlockWithName:(NSString *)path {
-    return [_typedefBlocksByName objectForKey:path];
+    return _typedefBlocksByName[path];
 }
 
 - (GBDocumentData *)customDocumentWithKey:(id)key {
-	return [_customDocumentsByKey objectForKey:key];
+	return _customDocumentsByKey[key];
 }
 
 @synthesize classes = _classes;

--- a/Parsing/GBParser.m
+++ b/Parsing/GBParser.m
@@ -199,8 +199,7 @@
 }
 
 - (BOOL)isFileIgnored:(NSString *)filename {
-	if ([filename isEqualToString:@".DS_Store"]) return YES;
-	return NO;
+	return [filename isEqualToString:@".DS_Store"];
 }
 
 - (BOOL)isDirectoryIgnored:(NSString *)filename {

--- a/Parsing/GBTokenizer.m
+++ b/Parsing/GBTokenizer.m
@@ -85,21 +85,21 @@
 	while (counter <= offset) {
 		NSUInteger index = self.tokenIndex + delta;
 		if (index >= [self.tokens count]) return [PKToken EOFToken];
-		if ([[self.tokens objectAtIndex:index] isComment]) {
+		if ([self.tokens[index] isComment]) {
 			delta++;
 			continue;
 		}
 		delta++;
 		counter++;
 	}
-	return [self.tokens objectAtIndex:self.tokenIndex + delta - 1];
+	return self.tokens[self.tokenIndex + delta - 1];
 }
 
 - (void)lookaheadTo:(NSString *)end usingBlock:(void (^)(PKToken *token, BOOL *stop))block {
     NSUInteger tokenCount = [self.tokens count];
 	BOOL quit = NO;
     for (NSUInteger index = self.tokenIndex; index < tokenCount; ++index) {
-        PKToken *token = [self.tokens objectAtIndex:index];
+        PKToken *token = self.tokens[index];
 		if ([token isComment]) {
 			index++;
 			continue;
@@ -114,7 +114,7 @@
 
 - (PKToken *)currentToken {
 	if ([self eof]) return [PKToken EOFToken];
-	return [self.tokens objectAtIndex:self.tokenIndex];
+	return self.tokens[self.tokenIndex];
 }
 
 - (GBComment *)postfixCommentFrom:(PKToken *)startToken 
@@ -126,7 +126,7 @@
 		PKToken *token = nil;
 		do {
 			if (pos < self.tokens.count) {
-				token = [self.tokens objectAtIndex:pos];
+				token = self.tokens[pos];
 	
 				NSArray *postfixLines = [[token stringValue] componentsMatchedByRegex:self.singleLineCommentAfterRegex capture:1];
 				if ([postfixLines count] > 0) {

--- a/Processing/GBCommentsProcessor+CodeBlockProcessing.m
+++ b/Processing/GBCommentsProcessor+CodeBlockProcessing.m
@@ -40,23 +40,23 @@
         NSArray *captured = [string captureComponentsMatchedByRegex:pattern range:searchRange];
         if ([captured count] > 0) {
             NSAssert([captured count] == 6, @"Match didn't produce right number of components");
-            NSString *code = [captured objectAtIndex:1];
+            NSString *code = captured[1];
             NSRange codeRange = [string rangeOfString:code options:0 range:searchRange];
             NSAssert(codeRange.location != NSNotFound, @"Matched code string should be in original");
 
-            NSString *begin = [captured objectAtIndex:3];
-            NSString *end = [captured objectAtIndex:5];
+            NSString *begin = captured[3];
+            NSString *end = captured[5];
             if (([begin isEqualToString:@"@code"] && [end isEqualToString:@"@endcode"]) || [begin isEqualToString:end]) {
                 NSDictionary *component = @{@"code": code,
-                                            @"prefix": [captured objectAtIndex:2],
+                                            @"prefix": captured[2],
                                             @"begin": begin,
-                                            @"postfix": [captured objectAtIndex:4],
+                                            @"postfix": captured[4],
                                             @"end": end,
                                             @"range": [NSValue valueWithRange:codeRange]};
                 [result addObject:component];
             }
 
-            NSString *matchedString = [captured objectAtIndex:0];
+            NSString *matchedString = captured[0];
             NSRange matchedRange = [string rangeOfString:matchedString options:0 range:searchRange];
             NSAssert(matchedRange.location != NSNotFound, @"Matched string should be in original");
             searchRange.location = matchedRange.location + matchedRange.length;
@@ -77,11 +77,11 @@
  @return YES if the link component shares any text in common with the source-code-block component.
  */
 - (BOOL)linkComponent:(NSDictionary*)link overlapsCodeComponent:(NSDictionary*)code {
-    NSRange linkRange = [[link objectForKey:@"range"] rangeValue];
+    NSRange linkRange = [link[@"range"] rangeValue];
     NSUInteger linkBegin = linkRange.location;
     NSUInteger linkEnd = linkRange.location + linkRange.length;
 
-    NSRange codeRange = [[code objectForKey:@"range"] rangeValue];
+    NSRange codeRange = [code[@"range"] rangeValue];
     NSUInteger codeBegin = codeRange.location;
     NSUInteger codeEnd = codeRange.location + codeRange.length;
     return (linkBegin >= codeBegin && linkBegin < codeEnd) || (linkEnd > codeBegin && linkEnd <= codeEnd);

--- a/Processing/GBProcessor.m
+++ b/Processing/GBProcessor.m
@@ -243,13 +243,13 @@
 	}];
 	NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithCapacity:[comment.methodParameters count]];
 	[comment.methodParameters enumerateObjectsUsingBlock:^(GBCommentArgument *parameter, NSUInteger idx, BOOL *stop) {
-		[parameters setObject:parameter forKey:parameter.argumentName];
+		parameters[parameter.argumentName] = parameter;
 	}];
 	
 	// Sort the parameters in the same order as in the method. Warn if any parameter is not found. Also warn if there are more parameters in the comment than the method defines. Note that we still add these descriptions to the end of the sorted list!
 	NSMutableArray *sorted = [NSMutableArray arrayWithCapacity:[parameters count]];
 	[names enumerateObjectsUsingBlock:^(NSString *name, NSUInteger idx, BOOL *stop) {
-		GBCommentArgument *parameter = [parameters objectForKey:name];
+		GBCommentArgument *parameter = parameters[name];
 		if (!parameter) {
             if (self.settings.warnOnMissingMethodArgument && method.includeInOutput)
                 GBLogXWarn(comment.sourceInfo, @"%@: Description for parameter '%@' missing for %@!", comment.sourceInfo, name, method);
@@ -416,7 +416,7 @@
 			if (!self.settings.keepMergedCategoriesSections) {
 				GBLogDebug(@"Creating single section for methods merged from %@...", category);
 				NSString *key = category.isExtension ? @"mergedExtensionSectionTitle" :  @"mergedCategorySectionTitle";
-				NSString *template = [self.settings.stringTemplates.objectPage objectForKey:key];
+				NSString *template = self.settings.stringTemplates.objectPage[key];
 				NSString *name = category.isExtension ? template : [NSString stringWithFormat:template, category.nameOfCategory];
 				[classMethodProvider registerSectionWithName:name];
 			}
@@ -426,7 +426,7 @@
 				GBLogDebug(@"Merging section %@ from %@...", section, category);
 				if (self.settings.keepMergedCategoriesSections) {
 					if (self.settings.prefixMergedCategoriesSectionsWithCategoryName && !category.isExtension) {
-						NSString *template = [self.settings.stringTemplates.objectPage objectForKey:@"mergedPrefixedCategorySectionTitle"];
+						NSString *template = self.settings.stringTemplates.objectPage[@"mergedPrefixedCategorySectionTitle"];
 						NSString *name = [NSString stringWithFormat:template, category.nameOfCategory, section.sectionName];
 						[classMethodProvider registerSectionWithName:name];
 					} else {

--- a/Testing/GBAdoptedProtocolsProviderTesting.m
+++ b/Testing/GBAdoptedProtocolsProviderTesting.m
@@ -25,7 +25,7 @@
 	// verify
 	assertThatBool([provider.protocols containsObject:protocol], equalToBool(YES));
 	assertThatInteger([[provider.protocols allObjects] count], equalToInteger(1));
-	assertThat([[provider.protocols allObjects] objectAtIndex:0], is(protocol));
+	assertThat([provider.protocols allObjects][0], is(protocol));
 }
 
 - (void)testRegisterProtocol_shouldIgnoreSameInstance {
@@ -68,9 +68,9 @@
 	// verify - only basic verification here, details within GBProtocolDataTesting!
 	NSArray *protocols = [original protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(3));
-	assertThat([[protocols objectAtIndex:0] nameOfProtocol], is(@"P1"));
-	assertThat([[protocols objectAtIndex:1] nameOfProtocol], is(@"P2"));
-	assertThat([[protocols objectAtIndex:2] nameOfProtocol], is(@"P3"));
+	assertThat([protocols[0] nameOfProtocol], is(@"P1"));
+	assertThat([protocols[1] nameOfProtocol], is(@"P2"));
+	assertThat([protocols[2] nameOfProtocol], is(@"P3"));
 }
 
 - (void)testMergeDataFromProtocolProvider_shouldPreserveSourceData {
@@ -86,8 +86,8 @@
 	// verify - only basic verification here, details within GBProtocolDataTesting!
 	NSArray *protocols = [source protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(2));
-	assertThat([[protocols objectAtIndex:0] nameOfProtocol], is(@"P1"));
-	assertThat([[protocols objectAtIndex:1] nameOfProtocol], is(@"P3"));
+	assertThat([protocols[0] nameOfProtocol], is(@"P1"));
+	assertThat([protocols[1] nameOfProtocol], is(@"P3"));
 }
 
 #pragma mark Protocols replacing handling
@@ -105,8 +105,8 @@
 	// verify
 	NSArray *protocols = [provider protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(2));
-	assertThat([[protocols objectAtIndex:0] nameOfProtocol], is(@"P2"));
-	assertThat([[protocols objectAtIndex:1] nameOfProtocol], is(@"P3"));
+	assertThat([protocols[0] nameOfProtocol], is(@"P2"));
+	assertThat([protocols[1] nameOfProtocol], is(@"P3"));
 }
 
 @end

--- a/Testing/GBApplicationTesting.m
+++ b/Testing/GBApplicationTesting.m
@@ -594,7 +594,7 @@
 	
 	// send all KVC messages for all options
 	for (NSUInteger i=0; i<[arguments count]; i++) {
-		NSString *arg = [arguments objectAtIndex:i];
+		NSString *arg = arguments[i];
 		if ([arg hasPrefix:@"--"]) {
 			// get the key corresponding to the argument
 			NSString *key = [DDGetoptLongParser optionToKey:arg];
@@ -603,14 +603,14 @@
 			
 			// if we have a value following, use it for KVC, otherwise just send YES
 			if (i < [arguments count] - 1) {
-				NSString *value = [arguments objectAtIndex:i+1];
+				NSString *value = arguments[i + 1];
 				if (![value hasPrefix:@"--"]) {
 					[application setValue:value forKey:key];
 					i++;
 					continue;
 				}
 			}
-			[application setValue:[NSNumber numberWithBool:YES] forKey:key];
+			[application setValue:@YES forKey:key];
 		}
 	}	
 	

--- a/Testing/GBCommentComponentsListTesting.m
+++ b/Testing/GBCommentComponentsListTesting.m
@@ -32,7 +32,7 @@
 	[list registerComponent:[GBCommentComponent componentWithStringValue:@"a"]];
 	// verify
 	assertThatInteger([list.components count], equalToInteger(1));
-	assertThat([[list.components objectAtIndex:0] stringValue], is(@"a"));
+	assertThat([list.components[0] stringValue], is(@"a"));
 }
 
 - (void)testRegisterComponent_shouldAddComponentsToArrayInOrder {
@@ -44,9 +44,9 @@
 	[list registerComponent:[GBCommentComponent componentWithStringValue:@"c"]];
 	// verify
 	assertThatInteger([list.components count], equalToInteger(3));
-	assertThat([[list.components objectAtIndex:0] stringValue], is(@"a"));
-	assertThat([[list.components objectAtIndex:1] stringValue], is(@"b"));
-	assertThat([[list.components objectAtIndex:2] stringValue], is(@"c"));
+	assertThat([list.components[0] stringValue], is(@"a"));
+	assertThat([list.components[1] stringValue], is(@"b"));
+	assertThat([list.components[2] stringValue], is(@"c"));
 }
 
 @end

--- a/Testing/GBCommentsProcessor-MarkdownTesting.m
+++ b/Testing/GBCommentsProcessor-MarkdownTesting.m
@@ -410,8 +410,8 @@
 	
 	assertThatInteger([comment.longDescription.components count], equalToInteger([expectations count]));
 	for (NSUInteger i=0; i<[expectations count]; i++) {
-		GBCommentComponent *component = [comment.longDescription.components objectAtIndex:i];
-		NSString *expected = [expectations objectAtIndex:i];
+		GBCommentComponent *component = comment.longDescription.components[i];
+		NSString *expected = expectations[i];
 		assertThat(component.markdownValue, is(expected));
 	}
 }
@@ -427,8 +427,8 @@
 	
 	assertThatInteger([components.components count], equalToInteger([expectations count]));
 	for (NSUInteger i=0; i<[expectations count]; i++) {
-		GBCommentComponent *component = [components.components objectAtIndex:i];
-		NSString *expected = [expectations objectAtIndex:i];
+		GBCommentComponent *component = components.components[i];
+		NSString *expected = expectations[i];
 		assertThat(component.markdownValue, is(expected));
 	}
 }

--- a/Testing/GBCommentsProcessor-RegistrationsTesting.m
+++ b/Testing/GBCommentsProcessor-RegistrationsTesting.m
@@ -489,7 +489,7 @@
 
 - (OCMockObject *)settingsProviderRepeatFirst:(BOOL)repeat {
 	OCMockObject *result = [GBTestObjectsRegistry mockSettingsProvider];
-	[[[result stub] andReturnValue:[NSNumber numberWithBool:repeat]] repeatFirstParagraphForMemberDescription];
+	[[[result stub] andReturnValue:@(repeat)] repeatFirstParagraphForMemberDescription];
 	return result;
 }
 

--- a/Testing/GBIvarsProviderTesting.m
+++ b/Testing/GBIvarsProviderTesting.m
@@ -18,19 +18,19 @@
 - (void)testRegisterIvar_shouldAddIvarToList {
 	// setup
 	GBIvarsProvider *provider = [[GBIvarsProvider alloc] initWithParentObject:self];
-	GBIvarData *ivar = [GBIvarData ivarDataWithComponents:[NSArray arrayWithObjects:@"NSUInteger", @"_name", nil]];
+	GBIvarData *ivar = [GBIvarData ivarDataWithComponents:@[@"NSUInteger", @"_name"]];
 	// execute
 	[provider registerIvar:ivar];
 	// verify
 	assertThatBool([provider.ivars containsObject:ivar], equalToBool(YES));
 	assertThatInteger([provider.ivars count], equalToInteger(1));
-	assertThat([provider.ivars objectAtIndex:0], is(ivar));
+	assertThat(provider.ivars[0], is(ivar));
 }
 
 - (void)testRegisterIvar_shouldSetParentObject {
 	// setup
 	GBIvarsProvider *provider = [[GBIvarsProvider alloc] initWithParentObject:self];
-	GBIvarData *ivar = [GBIvarData ivarDataWithComponents:[NSArray arrayWithObjects:@"NSUInteger", @"_name", nil]];
+	GBIvarData *ivar = [GBIvarData ivarDataWithComponents:@[@"NSUInteger", @"_name"]];
 	// execute
 	[provider registerIvar:ivar];
 	// verify
@@ -40,7 +40,7 @@
 - (void)testRegisterIvar_shouldIgnoreSameInstance {
 	// setup
 	GBIvarsProvider *provider = [[GBIvarsProvider alloc] initWithParentObject:self];
-	GBIvarData *ivar = [GBIvarData ivarDataWithComponents:[NSArray arrayWithObjects:@"NSUInteger", @"_name", nil]];
+	GBIvarData *ivar = [GBIvarData ivarDataWithComponents:@[@"NSUInteger", @"_name"]];
 	// execute
 	[provider registerIvar:ivar];
 	[provider registerIvar:ivar];
@@ -51,7 +51,7 @@
 - (void)testRegisterIvar_shouldMergeDifferentInstanceWithSameName {
 	// setup
 	GBIvarsProvider *provider = [[GBIvarsProvider alloc] initWithParentObject:self];
-	GBIvarData *source = [GBIvarData ivarDataWithComponents:[NSArray arrayWithObjects:@"int", @"_index", nil]];
+	GBIvarData *source = [GBIvarData ivarDataWithComponents:@[@"int", @"_index"]];
 	OCMockObject *destination = [OCMockObject niceMockForClass:[GBIvarData class]];
 	[[[destination stub] andReturn:@"_index"] nameOfIvar];
 	[[destination expect] mergeDataFromObject:source];
@@ -77,9 +77,9 @@
 	// verify - only basic testing here, details at GBIvarDataTesting!
 	NSArray *ivars = [original ivars];
 	assertThatInteger([ivars count], equalToInteger(3));
-	assertThat([[ivars objectAtIndex:0] nameOfIvar], is(@"_i1"));
-	assertThat([[ivars objectAtIndex:1] nameOfIvar], is(@"_i2"));
-	assertThat([[ivars objectAtIndex:2] nameOfIvar], is(@"_i3"));
+	assertThat([ivars[0] nameOfIvar], is(@"_i1"));
+	assertThat([ivars[1] nameOfIvar], is(@"_i2"));
+	assertThat([ivars[2] nameOfIvar], is(@"_i3"));
 }
 
 - (void)testMergeDataFromIvarsProvider_shouldPreserveSourceData {
@@ -95,8 +95,8 @@
 	// verify - only basic testing here, details at GBIvarDataTesting!
 	NSArray *ivars = [source ivars];
 	assertThatInteger([ivars count], equalToInteger(2));
-	assertThat([[ivars objectAtIndex:0] nameOfIvar], is(@"_i1"));
-	assertThat([[ivars objectAtIndex:1] nameOfIvar], is(@"_i3"));
+	assertThat([ivars[0] nameOfIvar], is(@"_i1"));
+	assertThat([ivars[1] nameOfIvar], is(@"_i3"));
 }
 
 @end

--- a/Testing/GBMethodDataTesting.m
+++ b/Testing/GBMethodDataTesting.m
@@ -76,8 +76,8 @@
 
 - (void)testMethodData_shouldInitializePropertyWithSingleComponent {
 	// setup & execute
-	NSArray *attributes = [NSArray arrayWithObjects:@"readonly", nil];
-	NSArray *components = [NSArray arrayWithObjects:@"UIView", @"*", @"value", nil];
+	NSArray *attributes = @[@"readonly"];
+	NSArray *components = @[@"UIView", @"*", @"value"];
 	GBMethodData *data = [GBMethodData propertyDataWithAttributes:attributes components:components];
 	// verify
 	assertThat(data.methodAttributes, onlyContains(@"readonly", nil));
@@ -87,8 +87,8 @@
 
 - (void)testMethodData_shouldInitializePropertyWithMultipleComponents {
 	// setup & execute
-	NSArray *attributes = [NSArray arrayWithObjects:@"nonatomic", @"assign", nil];
-	NSArray *components = [NSArray arrayWithObjects:@"IBOutlet", @"UIView", @"*", @"value", nil];
+	NSArray *attributes = @[@"nonatomic", @"assign"];
+	NSArray *components = @[@"IBOutlet", @"UIView", @"*", @"value"];
 	GBMethodData *data = [GBMethodData propertyDataWithAttributes:attributes components:components];
 	// verify
 	assertThat(data.methodAttributes, onlyContains(@"nonatomic", @"assign", nil));
@@ -111,43 +111,43 @@
 
 - (void)testMergeDataFromObject_shouldMergeMethodWithDifferentResultType {
 	// setup
-	GBMethodData *original = [GBMethodData methodDataWithType:GBMethodTypeInstance result:[NSArray arrayWithObject:@"id"] arguments:[NSArray arrayWithObject:[GBMethodArgument methodArgumentWithName:@"method"]]];
-	GBMethodData *source = [GBMethodData methodDataWithType:GBMethodTypeInstance result:[NSArray arrayWithObject:@"NSString *"] arguments:[NSArray arrayWithObject:[GBMethodArgument methodArgumentWithName:@"method"]]];
+	GBMethodData *original = [GBMethodData methodDataWithType:GBMethodTypeInstance result:@[@"id"] arguments:@[[GBMethodArgument methodArgumentWithName:@"method"]]];
+	GBMethodData *source = [GBMethodData methodDataWithType:GBMethodTypeInstance result:@[@"NSString *"] arguments:@[[GBMethodArgument methodArgumentWithName:@"method"]]];
 	// execute
 	[original mergeDataFromObject:source];
 	// verify - should keep original return type
 	assertThatInteger([original.methodResultTypes count], equalToInteger(1));
-	assertThat([original.methodResultTypes objectAtIndex:0], is(@"id"));
+	assertThat(original.methodResultTypes[0], is(@"id"));
 }
 
 - (void)testMergeDataFromObject_shouldMergePropertyWithDifferentResultType {
 	// setup
-	GBMethodData *original = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"readonly", @"retain", nil] components:[NSArray arrayWithObjects:@"id", @"value", nil]];
-	GBMethodData *source = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"readwrite", @"retain", nil] components:[NSArray arrayWithObjects:@"NSString *", @"value", nil]];
+	GBMethodData *original = [GBMethodData propertyDataWithAttributes:@[@"readonly", @"retain"] components:@[@"id", @"value"]];
+	GBMethodData *source = [GBMethodData propertyDataWithAttributes:@[@"readwrite", @"retain"] components:@[@"NSString *", @"value"]];
 	// execute
 	[original mergeDataFromObject:source];
 	// verify - should keep original return type
 	assertThatInteger([original.methodResultTypes count], equalToInteger(1));
-	assertThat([original.methodResultTypes objectAtIndex:0], is(@"id"));
+	assertThat(original.methodResultTypes[0], is(@"id"));
 }
 
 - (void)testMergeDataFromObject_shouldMergePropertyWithDifferentAttributes {
 	// setup
-	GBMethodData *original = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"readonly", @"retain", nil] components:[NSArray arrayWithObjects:@"BOOL", @"value", nil]];
-	GBMethodData *source = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"readwrite", @"retain", nil] components:[NSArray arrayWithObjects:@"BOOL", @"value", nil]];
+	GBMethodData *original = [GBMethodData propertyDataWithAttributes:@[@"readonly", @"retain"] components:@[@"BOOL", @"value"]];
+	GBMethodData *source = [GBMethodData propertyDataWithAttributes:@[@"readwrite", @"retain"] components:@[@"BOOL", @"value"]];
 	// execute
 	[original mergeDataFromObject:source];
 	// verify - should keep original attributes
-	assertThat([original.methodAttributes objectAtIndex:0], is(@"readonly"));
-	assertThat([original.methodAttributes objectAtIndex:1], is(@"retain"));
+	assertThat(original.methodAttributes[0], is(@"readonly"));
+	assertThat(original.methodAttributes[1], is(@"retain"));
 }
 
 - (void)testMergeDataFromObject_shouldMergeManualPropertyGetterImplementation {
 	// setup
-	GBMethodData *original = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"readonly", nil] components:[NSArray arrayWithObjects:@"BOOL", @"value", nil]];
+	GBMethodData *original = [GBMethodData propertyDataWithAttributes:@[@"readonly"] components:@[@"BOOL", @"value"]];
 	[original registerSourceInfo:[GBSourceInfo infoWithFilename:@"file1" lineNumber:1]];
 	GBMethodArgument *arg = [GBMethodArgument methodArgumentWithName:@"value"];
-	GBMethodData *source = [GBMethodData methodDataWithType:GBMethodTypeInstance result:[NSArray arrayWithObject:@"BOOL"] arguments:[NSArray arrayWithObject:arg]];
+	GBMethodData *source = [GBMethodData methodDataWithType:GBMethodTypeInstance result:@[@"BOOL"] arguments:@[arg]];
 	[source registerSourceInfo:[GBSourceInfo infoWithFilename:@"file2" lineNumber:1]];
 	// execute
 	[original mergeDataFromObject:source];
@@ -157,7 +157,7 @@
 
 - (void)testMergeDataFromObject_shouldMergeManualPropertySetterImplementation {
 	// setup
-	GBMethodData *original = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"readonly", nil] components:[NSArray arrayWithObjects:@"BOOL", @"value", nil]];
+	GBMethodData *original = [GBMethodData propertyDataWithAttributes:@[@"readonly"] components:@[@"BOOL", @"value"]];
 	[original registerSourceInfo:[GBSourceInfo infoWithFilename:@"file1" lineNumber:1]];
 	GBMethodData *source = [GBTestObjectsRegistry instanceMethodWithNames:@"setValue", nil];
 	[source registerSourceInfo:[GBSourceInfo infoWithFilename:@"file2" lineNumber:1]];
@@ -169,10 +169,10 @@
 
 - (void)testMergeDataFromObject_shouldMergeManualPropertyGetterAndSetterImplementation {
 	// setup
-	GBMethodData *original = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"readonly", nil] components:[NSArray arrayWithObjects:@"BOOL", @"value", nil]];
+	GBMethodData *original = [GBMethodData propertyDataWithAttributes:@[@"readonly"] components:@[@"BOOL", @"value"]];
 	[original registerSourceInfo:[GBSourceInfo infoWithFilename:@"file1" lineNumber:1]];
 	GBMethodArgument *arg = [GBMethodArgument methodArgumentWithName:@"value"];
-	GBMethodData *getter = [GBMethodData methodDataWithType:GBMethodTypeInstance result:[NSArray arrayWithObject:@"BOOL"] arguments:[NSArray arrayWithObject:arg]];
+	GBMethodData *getter = [GBMethodData methodDataWithType:GBMethodTypeInstance result:@[@"BOOL"] arguments:@[arg]];
 	[getter registerSourceInfo:[GBSourceInfo infoWithFilename:@"file2" lineNumber:1]];
 	GBMethodData *setter = [GBTestObjectsRegistry instanceMethodWithNames:@"setValue", nil];
 	[setter registerSourceInfo:[GBSourceInfo infoWithFilename:@"file3" lineNumber:1]];
@@ -185,15 +185,15 @@
 
 - (void)testMergeDataFromObject_shouldUseArgumentNamesFromComment {
 	// setup
-	GBMethodArgument *arg1 = [GBMethodArgument methodArgumentWithName:@"method" types:[NSArray arrayWithObject:@"id"] var:@"var"];
+	GBMethodArgument *arg1 = [GBMethodArgument methodArgumentWithName:@"method" types:@[@"id"] var:@"var"];
 	GBMethodData *original = [GBTestObjectsRegistry instanceMethodWithArguments:arg1, nil];
-	GBMethodArgument *arg2 = [GBMethodArgument methodArgumentWithName:@"method" types:[NSArray arrayWithObject:@"id"] var:@"theVar"];
+	GBMethodArgument *arg2 = [GBMethodArgument methodArgumentWithName:@"method" types:@[@"id"] var:@"theVar"];
 	GBMethodData *source = [GBTestObjectsRegistry instanceMethodWithArguments:arg2, nil];
 	[source setComment:[GBComment commentWithStringValue:@"Comment"]];
 	// execute
 	[original mergeDataFromObject:source];
 	// verify
-	GBMethodArgument *mergedArgument = [original.methodArguments objectAtIndex:0];
+	GBMethodArgument *mergedArgument = original.methodArguments[0];
 	assertThat(mergedArgument.argumentVar, is(@"theVar"));
 }
 
@@ -201,11 +201,11 @@
 
 - (void)testPropertySelectors_shouldReturnProperValueForProperties {
 	// setup & execute
-	NSArray *components = [NSArray arrayWithObjects:@"BOOL", @"value", nil];
-	GBMethodData *property1 = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"readonly", nil] components:components];
-	GBMethodData *property2 = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"getter", @"=", @"isValue", nil] components:components];
-	GBMethodData *property3 = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"setter", @"=", @"setTheValue:", nil] components:components];
-	GBMethodData *property4 = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"getter", @"=", @"isValue", @"setter", @"=", @"setTheValue:", nil] components:components];
+	NSArray *components = @[@"BOOL", @"value"];
+	GBMethodData *property1 = [GBMethodData propertyDataWithAttributes:@[@"readonly"] components:components];
+	GBMethodData *property2 = [GBMethodData propertyDataWithAttributes:@[@"getter", @"=", @"isValue"] components:components];
+	GBMethodData *property3 = [GBMethodData propertyDataWithAttributes:@[@"setter", @"=", @"setTheValue:"] components:components];
+	GBMethodData *property4 = [GBMethodData propertyDataWithAttributes:@[@"getter", @"=", @"isValue", @"setter", @"=", @"setTheValue:"] components:components];
 	// verify
 	assertThat(property1.propertyGetterSelector, is(@"value"));
 	assertThat(property1.propertySetterSelector, is(@"setValue:"));
@@ -275,8 +275,8 @@
 
 - (void)testFormattedComponents_shouldReturnSimplePropertyComponents {
 	// setup
-	NSArray *attributes = [NSArray arrayWithObjects:@"readonly", nil];
-	NSArray *components = [NSArray arrayWithObjects:@"BOOL", @"name", nil];
+	NSArray *attributes = @[@"readonly"];
+	NSArray *components = @[@"BOOL", @"name"];
 	GBMethodData *method = [GBMethodData propertyDataWithAttributes:attributes components:components];
 	// execute
 	NSArray *result = [method formattedComponents];
@@ -296,8 +296,8 @@
 
 - (void)testFormattedComponents_shouldReturnComplexPropertyComponents {
 	// setup
-	NSArray *attributes = [NSArray arrayWithObjects:@"readonly", @"nonatomic", nil];
-	NSArray *components = [NSArray arrayWithObjects:@"unsigned", @"int", @"name", nil];
+	NSArray *attributes = @[@"readonly", @"nonatomic"];
+	NSArray *components = @[@"unsigned", @"int", @"name"];
 	GBMethodData *method = [GBMethodData propertyDataWithAttributes:attributes components:components];
 	// execute
 	NSArray *result = [method formattedComponents];
@@ -323,7 +323,7 @@
 - (void)testFormattedComponents_shouldProperlyHandlePropertyWithNoAttributes {
 	// setup
 	NSArray *attributes = [NSArray array];
-	NSArray *components = [NSArray arrayWithObjects:@"NSString", @"*", @"name", nil];
+	NSArray *components = @[@"NSString", @"*", @"name"];
 	GBMethodData *method = [GBMethodData propertyDataWithAttributes:attributes components:components];
 	// execute
 	NSArray *result = [method formattedComponents];
@@ -340,8 +340,8 @@
 
 - (void)testFormattedComponents_shouldReturnPointerPropertyComponents {
 	// setup
-	NSArray *attributes = [NSArray arrayWithObjects:@"readonly", nil];
-	NSArray *components = [NSArray arrayWithObjects:@"NSString", @"*", @"name", nil];
+	NSArray *attributes = @[@"readonly"];
+	NSArray *components = @[@"NSString", @"*", @"name"];
 	GBMethodData *method = [GBMethodData propertyDataWithAttributes:attributes components:components];
 	// execute
 	NSArray *result = [method formattedComponents];
@@ -362,8 +362,8 @@
 
 - (void)testFormattedComponents_shouldCombineGetterAndSetterAttributes {
 	// setup
-	NSArray *attributes = [NSArray arrayWithObjects:@"readonly", @"getter", @"=", @"isName", @"setter", @"=", @"setName:", nil];
-	NSArray *components = [NSArray arrayWithObjects:@"NSString", @"*", @"name", nil];
+	NSArray *attributes = @[@"readonly", @"getter", @"=", @"isName", @"setter", @"=", @"setName:"];
+	NSArray *components = @[@"NSString", @"*", @"name"];
 	GBMethodData *method = [GBMethodData propertyDataWithAttributes:attributes components:components];
 	// execute
 	NSArray *result = [method formattedComponents];
@@ -394,8 +394,8 @@
 
 - (void)testFormattedComponents_shouldReturnSimpleInstanceMethodComponents {
 	// setup
-	NSArray *results = [NSArray arrayWithObjects:@"void", nil];
-	NSArray *arguments = [NSArray arrayWithObjects:[GBMethodArgument methodArgumentWithName:@"method"], nil];
+	NSArray *results = @[@"void"];
+	NSArray *arguments = @[[GBMethodArgument methodArgumentWithName:@"method"]];
 	GBMethodData *method = [GBMethodData methodDataWithType:GBMethodTypeInstance result:results arguments:arguments];
 	// execute
 	NSArray *result = [method formattedComponents];
@@ -412,9 +412,9 @@
 
 - (void)testFormattedComponents_shouldReturnSingleArgumentInstanceMethodComponents {
 	// setup
-	NSArray *results = [NSArray arrayWithObjects:@"unsigned", @"int", nil];
-	NSArray *types = [NSArray arrayWithObjects:@"bla", @"blu", nil];
-	NSArray *arguments = [NSArray arrayWithObjects:[GBMethodArgument methodArgumentWithName:@"method" types:types var:@"val"], nil];
+	NSArray *results = @[@"unsigned", @"int"];
+	NSArray *types = @[@"bla", @"blu"];
+	NSArray *arguments = @[[GBMethodArgument methodArgumentWithName:@"method" types:types var:@"val"]];
 	GBMethodData *method = [GBMethodData methodDataWithType:GBMethodTypeInstance result:results arguments:arguments];
 	// execute
 	NSArray *result = [method formattedComponents];
@@ -440,11 +440,10 @@
 
 - (void)testFormattedComponents_shouldReturnMultiArgumentInstanceMethodComponents {
 	// setup
-	NSArray *results = [NSArray arrayWithObjects:@"BOOL", nil];
-	NSArray *types = [NSArray arrayWithObjects:@"int", nil];
-	NSArray *arguments = [NSArray arrayWithObjects:
-						  [GBMethodArgument methodArgumentWithName:@"doSomething" types:types var:@"val"], 
-						  [GBMethodArgument methodArgumentWithName:@"withOperator" types:types var:@"op"], nil];
+	NSArray *results = @[@"BOOL"];
+	NSArray *types = @[@"int"];
+	NSArray *arguments = @[[GBMethodArgument methodArgumentWithName:@"doSomething" types:types var:@"val"],
+			[GBMethodArgument methodArgumentWithName:@"withOperator" types:types var:@"op"]];
 	GBMethodData *method = [GBMethodData methodDataWithType:GBMethodTypeInstance result:results arguments:arguments];
 	// execute
 	NSArray *result = [method formattedComponents];
@@ -473,9 +472,9 @@
 
 - (void)testFormattedComponents_shouldReturnPointerInstanceMethodComponents {
 	// setup
-	NSArray *results = [NSArray arrayWithObjects:@"NSArray", @"*", nil];
-	NSArray *types = [NSArray arrayWithObjects:@"NSString", @"*", nil];
-	NSArray *arguments = [NSArray arrayWithObjects:[GBMethodArgument methodArgumentWithName:@"method" types:types var:@"val"], nil];
+	NSArray *results = @[@"NSArray", @"*"];
+	NSArray *types = @[@"NSString", @"*"];
+	NSArray *arguments = @[[GBMethodArgument methodArgumentWithName:@"method" types:types var:@"val"]];
 	GBMethodData *method = [GBMethodData methodDataWithType:GBMethodTypeInstance result:results arguments:arguments];
 	// execute
 	NSArray *result = [method formattedComponents];
@@ -501,10 +500,10 @@
 
 - (void)testFormattedComponents_shouldReturnVariableArgumentInstanceMethodComponents {
 	// setup
-	NSArray *results = [NSArray arrayWithObjects:@"void", nil];
-	NSArray *types = [NSArray arrayWithObjects:@"id", nil];
+	NSArray *results = @[@"void"];
+	NSArray *types = @[@"id"];
 	NSArray *macros = [NSArray array];
-	NSArray *arguments = [NSArray arrayWithObjects:[GBMethodArgument methodArgumentWithName:@"method" types:types var:@"format" variableArg:YES terminationMacros:macros], nil];
+	NSArray *arguments = @[[GBMethodArgument methodArgumentWithName:@"method" types:types var:@"format" variableArg:YES terminationMacros:macros]];
 	GBMethodData *method = [GBMethodData methodDataWithType:GBMethodTypeInstance result:results arguments:arguments];
 	// execute
 	NSArray *result = [method formattedComponents];
@@ -529,8 +528,8 @@
 
 - (void)testFormattedComponents_shouldReturnClassMethodComponents {
 	// setup
-	NSArray *results = [NSArray arrayWithObjects:@"void", nil];
-	NSArray *arguments = [NSArray arrayWithObjects:[GBMethodArgument methodArgumentWithName:@"method"], nil];
+	NSArray *results = @[@"void"];
+	NSArray *arguments = @[[GBMethodArgument methodArgumentWithName:@"method"]];
 	GBMethodData *method = [GBMethodData methodDataWithType:GBMethodTypeClass result:results arguments:arguments];
 	// execute
 	NSArray *result = [method formattedComponents];
@@ -547,9 +546,9 @@
 
 - (void)testFormattedComponents_shouldNotAddSpaceForProtocols {
 	// setup
-	NSArray *results = [NSArray arrayWithObjects:@"NSArray", @"*", nil];
-	NSArray *types = [NSArray arrayWithObjects:@"id", @"<", @"Protocol", @">", nil];
-	NSArray *arguments = [NSArray arrayWithObjects:[GBMethodArgument methodArgumentWithName:@"method" types:types var:@"val"], nil];
+	NSArray *results = @[@"NSArray", @"*"];
+	NSArray *types = @[@"id", @"<", @"Protocol", @">"];
+	NSArray *arguments = @[[GBMethodArgument methodArgumentWithName:@"method" types:types var:@"val"]];
 	GBMethodData *method = [GBMethodData methodDataWithType:GBMethodTypeInstance result:results arguments:arguments];
 	// execute
 	NSArray *result = [method formattedComponents];

--- a/Testing/GBMethodsProviderTesting.m
+++ b/Testing/GBMethodsProviderTesting.m
@@ -25,7 +25,7 @@
 	[provider registerMethod:method];
 	// verify
 	assertThatInteger([provider.methods count], equalToInteger(1));
-	assertThat([[provider.methods objectAtIndex:0] methodSelector], is(@"method:"));
+	assertThat([provider.methods[0] methodSelector], is(@"method:"));
 }
 
 - (void)testRegisterMethod_shouldSetParentObject {
@@ -59,10 +59,10 @@
 	[provider registerMethod:method2];
 	// verify
 	assertThatInteger([provider.methods count], equalToInteger(2));
-	assertThat([[provider.methods objectAtIndex:0] methodSelector], is(@"method:"));
-	assertThatInteger([[provider.methods objectAtIndex:0] methodType], equalToInteger(GBMethodTypeInstance));
-	assertThat([[provider.methods objectAtIndex:1] methodSelector], is(@"method:"));
-	assertThatInteger([[provider.methods objectAtIndex:1] methodType], equalToInteger(GBMethodTypeClass));
+	assertThat([provider.methods[0] methodSelector], is(@"method:"));
+	assertThatInteger([provider.methods[0] methodType], equalToInteger(GBMethodTypeInstance));
+	assertThat([provider.methods[1] methodSelector], is(@"method:"));
+	assertThatInteger([provider.methods[1] methodType], equalToInteger(GBMethodTypeClass));
 }
 
 - (void)testRegisterMethod_shouldMapMethodBySelectorToInstanceMethodRegardlessOfRegistrationOrder {
@@ -123,7 +123,7 @@
 	[provider registerMethod:method];
 	// verify
 	assertThatInteger([provider.classMethods count], equalToInteger(1));
-	assertThat([provider.classMethods objectAtIndex:0], is(method));
+	assertThat(provider.classMethods[0], is(method));
 }
 
 - (void)testRegisterMethod_shouldRegisterInstanceMethod {
@@ -134,7 +134,7 @@
 	[provider registerMethod:method];
 	// verify
 	assertThatInteger([provider.instanceMethods count], equalToInteger(1));
-	assertThat([provider.instanceMethods objectAtIndex:0], is(method));
+	assertThat(provider.instanceMethods[0], is(method));
 }
 
 - (void)testRegisterMethod_shouldRegisterProperty {
@@ -145,7 +145,7 @@
 	[provider registerMethod:method];
 	// verify
 	assertThatInteger([provider.properties count], equalToInteger(1));
-	assertThat([provider.properties objectAtIndex:0], is(method));
+	assertThat(provider.properties[0], is(method));
 }
 
 - (void)testRegisterMethod_shouldRegisterDifferentTypesOfMethodsAndUseProperSorting {
@@ -166,23 +166,23 @@
 	[provider registerMethod:instance1];
 	// verify
 	assertThatInteger([provider.classMethods count], equalToInteger(2));
-	assertThat([provider.classMethods objectAtIndex:0], is(class1));
-	assertThat([provider.classMethods objectAtIndex:1], is(class2));
+	assertThat(provider.classMethods[0], is(class1));
+	assertThat(provider.classMethods[1], is(class2));
 	assertThatInteger([provider.instanceMethods count], equalToInteger(2));
-	assertThat([provider.instanceMethods objectAtIndex:0], is(instance1));
-	assertThat([provider.instanceMethods objectAtIndex:1], is(instance2));
+	assertThat(provider.instanceMethods[0], is(instance1));
+	assertThat(provider.instanceMethods[1], is(instance2));
 	assertThatInteger([provider.properties count], equalToInteger(2));
-	assertThat([provider.properties objectAtIndex:0], is(property1));
-	assertThat([provider.properties objectAtIndex:1], is(property2));
+	assertThat(provider.properties[0], is(property1));
+	assertThat(provider.properties[1], is(property2));
 }
 
 - (void)testRegisterMethod_shouldProperlyHandlePropertyGettersAndSetters {
 	// setup
 	GBMethodsProvider *provider = [[GBMethodsProvider alloc] initWithParentObject:self];
 	GBMethodData *property1 = [GBTestObjectsRegistry propertyMethodWithArgument:@"name1"];
-	GBMethodData *property2 = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"getter",@"=",@"isName2", nil] components:[NSArray arrayWithObjects:@"BOOL", @"name2", nil]];
-	GBMethodData *property3 = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"setter",@"=",@"setTheName3:", nil] components:[NSArray arrayWithObjects:@"BOOL", @"name3", nil]];
-	GBMethodData *property4 = [GBMethodData propertyDataWithAttributes:[NSArray arrayWithObjects:@"getter",@"=",@"isName4", @"setter",@"=",@"setTheName4:", nil] components:[NSArray arrayWithObjects:@"BOOL", @"name4", nil]];
+	GBMethodData *property2 = [GBMethodData propertyDataWithAttributes:@[@"getter", @"=", @"isName2"] components:@[@"BOOL", @"name2"]];
+	GBMethodData *property3 = [GBMethodData propertyDataWithAttributes:@[@"setter", @"=", @"setTheName3:"] components:@[@"BOOL", @"name3"]];
+	GBMethodData *property4 = [GBMethodData propertyDataWithAttributes:@[@"getter", @"=", @"isName4", @"setter", @"=", @"setTheName4:"] components:@[@"BOOL", @"name4"]];
 	// execute
 	[provider registerMethod:property1];
 	[provider registerMethod:property2];
@@ -223,7 +223,7 @@
 	// verify
 	assertThatInteger([[section1 methods] count], equalToInteger(0));
 	assertThatInteger([[section2 methods] count], equalToInteger(1));
-	assertThat([section2.methods objectAtIndex:0], is(method));
+	assertThat(section2.methods[0], is(method));
 }
 
 - (void)testRegisterMethod_shouldCreateDefaultSectionIfNoneExists {
@@ -234,9 +234,9 @@
 	[provider registerMethod:method];
 	// verify
 	assertThatInteger([[provider sections] count], equalToInteger(1));
-	GBMethodSectionData *section = [[provider sections] objectAtIndex:0];
+	GBMethodSectionData *section = [provider sections][0];
 	assertThatInteger([[section methods] count], equalToInteger(1));
-	assertThat([section.methods objectAtIndex:0], is(method));
+	assertThat(section.methods[0], is(method));
 }
 
 - (void)testRegisterSectionWithName_shouldCreateEmptySectionWithGivenName {
@@ -288,7 +288,7 @@
 	[provider unregisterEmptySections];
 	// verify
 	assertThatInteger([[provider sections] count], equalToInteger(1));
-	assertThat([[[provider sections] objectAtIndex:0] sectionName], is(@"Used"));
+	assertThat([[provider sections][0] sectionName], is(@"Used"));
 }
 
 #pragma mark Output helpers testing
@@ -367,9 +367,9 @@
 	// verify - only basic testing here, details at GBMethodDataTesting!
 	NSArray *methods = [original methods];
 	assertThatInteger([methods count], equalToInteger(3));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"m1:"));
-	assertThat([[methods objectAtIndex:1] methodSelector], is(@"m2:"));
-	assertThat([[methods objectAtIndex:2] methodSelector], is(@"m3:"));
+	assertThat([methods[0] methodSelector], is(@"m1:"));
+	assertThat([methods[1] methodSelector], is(@"m2:"));
+	assertThat([methods[2] methodSelector], is(@"m3:"));
 }
 
 - (void)testMergeDataFromObjectsProvider_shouldPreserveSourceData {
@@ -385,8 +385,8 @@
 	// verify - only basic testing here, details at GBMethodDataTesting!
 	NSArray *methods = [source methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"m1:"));
-	assertThat([[methods objectAtIndex:1] methodSelector], is(@"m3:"));
+	assertThat([methods[0] methodSelector], is(@"m1:"));
+	assertThat([methods[1] methodSelector], is(@"m3:"));
 }
 
 - (void)testMergeDataFromObjectsProvider_shouldMergeSections {
@@ -406,16 +406,16 @@
 	GBMethodSectionData *section = nil;
 	NSArray *sections = [original sections];
 	assertThatInteger([sections count], equalToInteger(2));
-	section = [sections objectAtIndex:0];
+	section = sections[0];
 	assertThat([section sectionName], is(@"Section1"));
 	assertThatInteger([section.methods count], equalToInteger(2));
-	assertThat([[section.methods objectAtIndex:0] methodSelector], is(@"m1:"));
-	assertThat([[section.methods objectAtIndex:1] methodSelector], is(@"m4:"));
-	section = [sections objectAtIndex:1];
+	assertThat([section.methods[0] methodSelector], is(@"m1:"));
+	assertThat([section.methods[1] methodSelector], is(@"m4:"));
+	section = sections[1];
 	assertThat([section sectionName], is(@"Section2"));
 	assertThatInteger([section.methods count], equalToInteger(2));
-	assertThat([[section.methods objectAtIndex:0] methodSelector], is(@"m2:"));
-	assertThat([[section.methods objectAtIndex:1] methodSelector], is(@"m3:"));
+	assertThat([section.methods[0] methodSelector], is(@"m2:"));
+	assertThat([section.methods[1] methodSelector], is(@"m3:"));
 }
 
 - (void)testMergeDataFromObjectsProvider_shouldAddMergedSectionsToEndOfOriginalSections {
@@ -434,15 +434,15 @@
 	GBMethodSectionData *section = nil;
 	NSArray *sections = [original sections];
 	assertThatInteger([sections count], equalToInteger(2));
-	section = [sections objectAtIndex:0];
+	section = sections[0];
 	assertThat([section sectionName], is(@"Section2"));
 	assertThatInteger([section.methods count], equalToInteger(2));
-	assertThat([[section.methods objectAtIndex:0] methodSelector], is(@"m1:"));
-	assertThat([[section.methods objectAtIndex:1] methodSelector], is(@"m3:"));
-	section = [sections objectAtIndex:1];
+	assertThat([section.methods[0] methodSelector], is(@"m1:"));
+	assertThat([section.methods[1] methodSelector], is(@"m3:"));
+	section = sections[1];
 	assertThat([section sectionName], is(@"Section1"));
 	assertThatInteger([section.methods count], equalToInteger(1));
-	assertThat([[section.methods objectAtIndex:0] methodSelector], is(@"m2:"));
+	assertThat([section.methods[0] methodSelector], is(@"m2:"));
 }
 
 - (void)testMergeDataFromObjectsProvider_shouldPreserveCurrentSectionForNewMethods {
@@ -461,16 +461,16 @@
 	GBMethodSectionData *section = nil;
 	NSArray *sections = [original sections];
 	assertThatInteger([sections count], equalToInteger(2));
-	section = [sections objectAtIndex:0];
+	section = sections[0];
 	assertThat([section sectionName], is(@"Section1"));
 	assertThatInteger([section.methods count], equalToInteger(3));
-	assertThat([[section.methods objectAtIndex:0] methodSelector], is(@"m1:"));
-	assertThat([[section.methods objectAtIndex:1] methodSelector], is(@"m3:"));
-	assertThat([[section.methods objectAtIndex:2] methodSelector], is(@"m4:"));
-	section = [sections objectAtIndex:1];
+	assertThat([section.methods[0] methodSelector], is(@"m1:"));
+	assertThat([section.methods[1] methodSelector], is(@"m3:"));
+	assertThat([section.methods[2] methodSelector], is(@"m4:"));
+	section = sections[1];
 	assertThat([section sectionName], is(@"Section2"));
 	assertThatInteger([section.methods count], equalToInteger(1));
-	assertThat([[section.methods objectAtIndex:0] methodSelector], is(@"m2:"));
+	assertThat([section.methods[0] methodSelector], is(@"m2:"));
 }
 
 - (void)testMergeDataFromObjectsProvider_shouldUseOriginalSectionForExistingMethodsEvenIfFoundInDifferentSection {
@@ -486,10 +486,10 @@
 	// verify
 	NSArray *sections = [original sections];
 	assertThatInteger([sections count], equalToInteger(1));
-	GBMethodSectionData *section = [sections objectAtIndex:0];
+	GBMethodSectionData *section = sections[0];
 	assertThat([section sectionName], is(@"Section1"));
 	assertThatInteger([section.methods count], equalToInteger(1));
-	assertThat([[section.methods objectAtIndex:0] methodSelector], is(@"m1:"));
+	assertThat([section.methods[0] methodSelector], is(@"m1:"));
 }
 
 - (void)testMergeDataFromObjectsProvider_shouldUseOriginalSectionForExistingMethodsFromDefaultSection {
@@ -504,10 +504,10 @@
 	// verify
 	NSArray *sections = [original sections];
 	assertThatInteger([sections count], equalToInteger(1));
-	GBMethodSectionData *section = [sections objectAtIndex:0];
+	GBMethodSectionData *section = sections[0];
 	assertThat([section sectionName], is(@"Section1"));
 	assertThatInteger([section.methods count], equalToInteger(1));
-	assertThat([[section.methods objectAtIndex:0] methodSelector], is(@"m1:"));
+	assertThat([section.methods[0] methodSelector], is(@"m1:"));
 }
 
 #pragma mark Unregistering handling
@@ -523,7 +523,7 @@
 	[provider unregisterMethod:method1];
 	// verify
 	assertThatInteger([provider.methods count], equalToInteger(1));
-	assertThat([provider.methods objectAtIndex:0], is(method2));
+	assertThat(provider.methods[0], is(method2));
 }
 
 - (void)testUnregisterMethod_shouldRemoveMethodFromMethodsBySelectors {
@@ -548,7 +548,7 @@
 	[provider unregisterMethod:method1];
 	// verify
 	assertThatInteger([provider.classMethods count], equalToInteger(1));
-	assertThat([provider.classMethods objectAtIndex:0], is(method2));
+	assertThat(provider.classMethods[0], is(method2));
 }
 
 - (void)testUnregisterMethod_shouldRemoveMethodFromInstanceMethods {
@@ -562,7 +562,7 @@
 	[provider unregisterMethod:method1];
 	// verify
 	assertThatInteger([provider.instanceMethods count], equalToInteger(1));
-	assertThat([provider.instanceMethods objectAtIndex:0], is(method2));
+	assertThat(provider.instanceMethods[0], is(method2));
 }
 
 - (void)testUnregisterMethod_shouldRemoveMethodFromProperties {
@@ -576,7 +576,7 @@
 	[provider unregisterMethod:method1];
 	// verify
 	assertThatInteger([provider.properties count], equalToInteger(1));
-	assertThat([provider.properties objectAtIndex:0], is(method2));
+	assertThat(provider.properties[0], is(method2));
 }
 
 - (void)testUnregisterMethod_shouldRemoveMethodFromSection {
@@ -591,9 +591,9 @@
 	[provider unregisterMethod:method1];
 	// verify
 	assertThatInteger([provider.sections count], equalToInteger(1));
-	GBMethodSectionData *section = [provider.sections objectAtIndex:0];
+	GBMethodSectionData *section = provider.sections[0];
 	assertThatInteger([section.methods count], equalToInteger(1));
-	assertThat([section.methods objectAtIndex:0], is(method2));
+	assertThat(section.methods[0], is(method2));
 }
 
 - (void)testUnregisterMethod_shouldRemoveSectionIfItContainsNoMoreMethod {

--- a/Testing/GBModelBaseTesting.m
+++ b/Testing/GBModelBaseTesting.m
@@ -28,12 +28,12 @@
 	// verify
 	NSArray *files = [original sourceInfosSortedByName];
 	assertThatInteger([files count], equalToInteger(3));
-	assertThat([[files objectAtIndex:0] filename], is(@"f1"));
-	assertThat([[files objectAtIndex:1] filename], is(@"f2"));
-	assertThat([[files objectAtIndex:2] filename], is(@"f3"));
-	assertThatInteger([[files objectAtIndex:0] lineNumber], equalToInteger(3));
-	assertThatInteger([[files objectAtIndex:1] lineNumber], equalToInteger(2));
-	assertThatInteger([[files objectAtIndex:2] lineNumber], equalToInteger(4));
+	assertThat([files[0] filename], is(@"f1"));
+	assertThat([files[1] filename], is(@"f2"));
+	assertThat([files[2] filename], is(@"f3"));
+	assertThatInteger([files[0] lineNumber], equalToInteger(3));
+	assertThatInteger([files[1] lineNumber], equalToInteger(2));
+	assertThatInteger([files[2] lineNumber], equalToInteger(4));
 }
 
 - (void)testMergeDataFromObject_shouldPreserveSourceDeclaredFiles {
@@ -49,10 +49,10 @@
 	// verify
 	NSArray *files = [source sourceInfosSortedByName];
 	assertThatInteger([files count], equalToInteger(2));
-	assertThat([[files objectAtIndex:0] filename], is(@"f1"));
-	assertThat([[files objectAtIndex:1] filename], is(@"f3"));
-	assertThatInteger([[files objectAtIndex:0] lineNumber], equalToInteger(2));
-	assertThatInteger([[files objectAtIndex:1] lineNumber], equalToInteger(1));
+	assertThat([files[0] filename], is(@"f1"));
+	assertThat([files[1] filename], is(@"f3"));
+	assertThatInteger([files[0] lineNumber], equalToInteger(2));
+	assertThatInteger([files[1] lineNumber], equalToInteger(1));
 }
 
 #pragma mark Comments merging handling

--- a/Testing/GBObjectiveCParser-AdoptedProtocolsParsingTesting.m
+++ b/Testing/GBObjectiveCParser-AdoptedProtocolsParsingTesting.m
@@ -26,7 +26,7 @@
 	// verify
 	NSArray *protocols = [[[[store classes] anyObject] adoptedProtocols] protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(1));
-	assertThat([[protocols objectAtIndex:0] nameOfProtocol], is(@"MyProtocol"));
+	assertThat([protocols[0] nameOfProtocol], is(@"MyProtocol"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterAllAdoptedProtocols {
@@ -38,8 +38,8 @@
 	// verify
 	NSArray *protocols = [[[[store classes] anyObject] adoptedProtocols] protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(2));
-	assertThat([[protocols objectAtIndex:0] nameOfProtocol], is(@"MyProtocol1"));
-	assertThat([[protocols objectAtIndex:1] nameOfProtocol], is(@"MyProtocol2"));
+	assertThat([protocols[0] nameOfProtocol], is(@"MyProtocol1"));
+	assertThat([protocols[1] nameOfProtocol], is(@"MyProtocol2"));
 }
 
 @end

--- a/Testing/GBObjectiveCParser-CategoryParsingTesting.m
+++ b/Testing/GBObjectiveCParser-CategoryParsingTesting.m
@@ -28,8 +28,8 @@
 	// verify
 	NSArray *categories = [store categoriesSortedByName];
 	assertThatInteger([categories count], equalToInteger(1));
-	assertThat([[categories objectAtIndex:0] nameOfClass], is(@"MyClass"));
-	assertThat([[categories objectAtIndex:0] nameOfCategory], is(@"MyCategory"));
+	assertThat([categories[0] nameOfClass], is(@"MyClass"));
+	assertThat([categories[0] nameOfCategory], is(@"MyCategory"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterCategoryDefinitionSourceFileAndLineNumber {
@@ -39,7 +39,7 @@
 	// execute
 	[parser parseObjectsFromString:@"@interface MyClass(MyCategory) @end" sourceFile:@"filename.h" toStore:store];
 	// verify
-	NSSet *files = [[[store categoriesSortedByName] objectAtIndex:0] sourceInfos];
+	NSSet *files = [[store categoriesSortedByName][0] sourceInfos];
 	assertThatInteger([files count], equalToInteger(1));
 	assertThat([[files anyObject] filename], is(@"filename.h"));
 	assertThatInteger([[files anyObject] lineNumber], equalToInteger(1));
@@ -52,7 +52,7 @@
 	// execute
 	[parser parseObjectsFromString:@"\n// cmt\n\n#define DEBUG\n\n/// hello\n@interface MyClass(MyCategory) @end" sourceFile:@"filename.h" toStore:store];
 	// verify
-	NSSet *files = [[[store categoriesSortedByName] objectAtIndex:0] sourceInfos];
+	NSSet *files = [[store categoriesSortedByName][0] sourceInfos];
 	assertThatInteger([[files anyObject] lineNumber], equalToInteger(7));
 }
 
@@ -65,8 +65,8 @@
 	// verify
 	NSArray *categories = [store categoriesSortedByName];
 	assertThatInteger([categories count], equalToInteger(2));
-	assertThat([[categories objectAtIndex:0] nameOfCategory], is(@"MyCategory1"));
-	assertThat([[categories objectAtIndex:1] nameOfCategory], is(@"MyCategory2"));
+	assertThat([categories[0] nameOfCategory], is(@"MyCategory1"));
+	assertThat([categories[1] nameOfCategory], is(@"MyCategory2"));
 }
 
 #pragma mark Categories declaration data parsing testing
@@ -80,8 +80,8 @@
 	// verify
 	NSArray *categories = [store categoriesSortedByName];
 	assertThatInteger([categories count], equalToInteger(1));
-	assertThat([[categories objectAtIndex:0] nameOfClass], is(@"MyClass"));
-	assertThat([[categories objectAtIndex:0] nameOfCategory], is(@"MyCategory"));
+	assertThat([categories[0] nameOfClass], is(@"MyClass"));
+	assertThat([categories[0] nameOfCategory], is(@"MyCategory"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterCategoryDeclarationSourceFileAndLineNumber {
@@ -91,7 +91,7 @@
 	// execute
 	[parser parseObjectsFromString:@"@implementation MyClass(MyCategory) @end" sourceFile:@"filename.h" toStore:store];
 	// verify
-	NSSet *files = [[[store categoriesSortedByName] objectAtIndex:0] sourceInfos];
+	NSSet *files = [[store categoriesSortedByName][0] sourceInfos];
 	assertThatInteger([files count], equalToInteger(1));
 	assertThat([[files anyObject] filename], is(@"filename.h"));
 	assertThatInteger([[files anyObject] lineNumber], equalToInteger(1));
@@ -104,7 +104,7 @@
 	// execute
 	[parser parseObjectsFromString:@"\n// cmt\n\n#define DEBUG\n\n/// hello\n@implementation MyClass(MyCategory) @end" sourceFile:@"filename.h" toStore:store];
 	// verify
-	NSSet *files = [[[store categoriesSortedByName] objectAtIndex:0] sourceInfos];
+	NSSet *files = [[store categoriesSortedByName][0] sourceInfos];
 	assertThatInteger([[files anyObject] lineNumber], equalToInteger(7));
 }
 
@@ -117,8 +117,8 @@
 	// verify
 	NSArray *categories = [store categoriesSortedByName];
 	assertThatInteger([categories count], equalToInteger(2));
-	assertThat([[categories objectAtIndex:0] nameOfCategory], is(@"MyCategory1"));
-	assertThat([[categories objectAtIndex:1] nameOfCategory], is(@"MyCategory2"));
+	assertThat([categories[0] nameOfCategory], is(@"MyCategory1"));
+	assertThat([categories[1] nameOfCategory], is(@"MyCategory2"));
 }
 
 #pragma mark Extensions common data parsing testing
@@ -132,8 +132,8 @@
 	// verify
 	NSArray *categories = [store categoriesSortedByName];
 	assertThatInteger([categories count], equalToInteger(1));
-	assertThat([[categories objectAtIndex:0] nameOfClass], is(@"MyClass"));
-	assertThat([[categories objectAtIndex:0] nameOfCategory], is(nil));
+	assertThat([categories[0] nameOfClass], is(@"MyClass"));
+	assertThat([categories[0] nameOfCategory], is(nil));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterExtensionSourceFileAndLineNumber {
@@ -143,7 +143,7 @@
 	// execute
 	[parser parseObjectsFromString:@"@interface MyClass() @end" sourceFile:@"filename.h" toStore:store];
 	// verify
-	NSSet *files = [[[store categoriesSortedByName] objectAtIndex:0] sourceInfos];
+	NSSet *files = [[store categoriesSortedByName][0] sourceInfos];
 	assertThatInteger([files count], equalToInteger(1));
 	assertThat([[files anyObject] filename], is(@"filename.h"));
 	assertThatInteger([[files anyObject] lineNumber], equalToInteger(1));
@@ -156,7 +156,7 @@
 	// execute
 	[parser parseObjectsFromString:@"\n// cmt\n\n#define DEBUG\n\n/// hello\n@interface MyClass() @end" sourceFile:@"filename.h" toStore:store];
 	// verify
-	NSSet *files = [[[store categoriesSortedByName] objectAtIndex:0] sourceInfos];
+	NSSet *files = [[store categoriesSortedByName][0] sourceInfos];
 	assertThatInteger([[files anyObject] lineNumber], equalToInteger(7));
 }
 
@@ -169,8 +169,8 @@
 	// verify
 	NSArray *categories = [store categoriesSortedByName];
 	assertThatInteger([categories count], equalToInteger(2));
-	assertThat([[categories objectAtIndex:0] nameOfClass], is(@"MyClass1"));
-	assertThat([[categories objectAtIndex:1] nameOfClass], is(@"MyClass2"));
+	assertThat([categories[0] nameOfClass], is(@"MyClass1"));
+	assertThat([categories[1] nameOfClass], is(@"MyClass2"));
 }
 
 #pragma mark Category comments parsing testing
@@ -288,7 +288,7 @@
 	GBCategoryData *category = [[store categories] anyObject];
 	NSArray *protocols = [category.adoptedProtocols protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(1));
-	assertThat([[protocols objectAtIndex:0] nameOfProtocol], is(@"Protocol"));
+	assertThat([protocols[0] nameOfProtocol], is(@"Protocol"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterCategoryMethods {
@@ -301,7 +301,7 @@
 	GBCategoryData *category = [[store categories] anyObject];
 	NSArray *methods = [category.methods methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method"));
+	assertThat([methods[0] methodSelector], is(@"method"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterCategoryProperties {
@@ -314,7 +314,7 @@
 	GBCategoryData *category = [[store categories] anyObject];
 	NSArray *methods = [category.methods methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"name"));
+	assertThat([methods[0] methodSelector], is(@"name"));
 }
 
 #pragma mark Extension definition components parsing testing
@@ -329,7 +329,7 @@
 	GBCategoryData *extension = [[store categories] anyObject];
 	NSArray *protocols = [extension.adoptedProtocols protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(1));
-	assertThat([[protocols objectAtIndex:0] nameOfProtocol], is(@"Protocol"));
+	assertThat([protocols[0] nameOfProtocol], is(@"Protocol"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterExtensionMethods {
@@ -342,7 +342,7 @@
 	GBCategoryData *extension = [[store categories] anyObject];
 	NSArray *methods = [extension.methods methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method"));
+	assertThat([methods[0] methodSelector], is(@"method"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterExtensionProperties {
@@ -355,7 +355,7 @@
 	GBCategoryData *extension = [[store categories] anyObject];
 	NSArray *methods = [extension.methods methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"name"));
+	assertThat([methods[0] methodSelector], is(@"name"));
 }
 
 #pragma mark Category declaration components parsing testing
@@ -370,7 +370,7 @@
 	GBCategoryData *category = [[store categories] anyObject];
 	NSArray *methods = [category.methods methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method"));
+	assertThat([methods[0] methodSelector], is(@"method"));
 }
 
 #pragma mark Category merging testing
@@ -387,8 +387,8 @@
 	GBClassData *category = [[store categories] anyObject];
 	NSArray *methods = [category.methods methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method1"));
-	assertThat([[methods objectAtIndex:1] methodSelector], is(@"method2"));
+	assertThat([methods[0] methodSelector], is(@"method1"));
+	assertThat([methods[1] methodSelector], is(@"method2"));
 }
 
 - (void)testParseObjectsFromString_shouldMergeCategoryDeclarations {
@@ -403,8 +403,8 @@
 	GBClassData *category = [[store categories] anyObject];
 	NSArray *methods = [category.methods methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method1"));
-	assertThat([[methods objectAtIndex:1] methodSelector], is(@"method2"));
+	assertThat([methods[0] methodSelector], is(@"method1"));
+	assertThat([methods[1] methodSelector], is(@"method2"));
 }
 
 - (void)testParseObjectsFromString_shouldMergeCategoryDefinitionAndDeclaration {
@@ -419,8 +419,8 @@
 	GBClassData *category = [[store categories] anyObject];
 	NSArray *methods = [category.methods methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method1"));
-	assertThat([[methods objectAtIndex:1] methodSelector], is(@"method2"));
+	assertThat([methods[0] methodSelector], is(@"method1"));
+	assertThat([methods[1] methodSelector], is(@"method2"));
 }
 
 #pragma mark Extension merging testing
@@ -437,8 +437,8 @@
 	GBCategoryData *category = [[store categories] anyObject];
 	NSArray *methods = [category.methods methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method1"));
-	assertThat([[methods objectAtIndex:1] methodSelector], is(@"method2"));
+	assertThat([methods[0] methodSelector], is(@"method1"));
+	assertThat([methods[1] methodSelector], is(@"method2"));
 }
 
 #pragma mark Complex parsing testing
@@ -452,10 +452,10 @@
 	// verify - we're not going into details here, just checking that top-level objects were properly parsed!
 	NSArray *categories = [store categoriesSortedByName];
 	assertThatInteger([categories count], equalToInteger(2));
-	assertThat([[categories objectAtIndex:0] nameOfClass], is(@"GBCalculator"));
-	assertThat([[categories objectAtIndex:0] nameOfCategory], is(nil));
-	assertThat([[categories objectAtIndex:1] nameOfClass], is(@"GBCalculator"));
-	assertThat([[categories objectAtIndex:1] nameOfCategory], is(@"Multiplication"));
+	assertThat([categories[0] nameOfClass], is(@"GBCalculator"));
+	assertThat([categories[0] nameOfCategory], is(nil));
+	assertThat([categories[1] nameOfClass], is(@"GBCalculator"));
+	assertThat([categories[1] nameOfCategory], is(@"Multiplication"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterCategoryFromRealLifeCodeInput {

--- a/Testing/GBObjectiveCParser-ClassParsingTesting.m
+++ b/Testing/GBObjectiveCParser-ClassParsingTesting.m
@@ -28,7 +28,7 @@
 	// verify
 	NSArray *classes = [store classesSortedByName];
 	assertThatInteger([classes count], equalToInteger(1));
-	assertThat([[classes objectAtIndex:0] nameOfClass], is(@"MyClass"));
+	assertThat([classes[0] nameOfClass], is(@"MyClass"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterClassDefinitionSourceFileAndLineNumber {
@@ -38,7 +38,7 @@
 	// execute
 	[parser parseObjectsFromString:@"@interface MyClass @end" sourceFile:@"filename.h" toStore:store];
 	// verify
-	NSSet *files = [[[store classesSortedByName] objectAtIndex:0] sourceInfos];
+	NSSet *files = [[store classesSortedByName][0] sourceInfos];
 	assertThatInteger([files count], equalToInteger(1));
 	assertThat([[files anyObject] filename], is(@"filename.h"));
 	assertThatInteger([[files anyObject] lineNumber], equalToInteger(1));
@@ -51,7 +51,7 @@
 	// execute
 	[parser parseObjectsFromString:@"\n// cmt\n\n#define DEBUG\n\n/// hello\n@interface MyClass @end" sourceFile:@"filename.h" toStore:store];
 	// verify
-	NSSet *files = [[[store classesSortedByName] objectAtIndex:0] sourceInfos];
+	NSSet *files = [[store classesSortedByName][0] sourceInfos];
 	assertThatInteger([[files anyObject] lineNumber], equalToInteger(7));
 }
 
@@ -64,8 +64,8 @@
 	// verify
 	NSArray *classes = [store classesSortedByName];
 	assertThatInteger([classes count], equalToInteger(2));
-	assertThat([[classes objectAtIndex:0] nameOfClass], is(@"MyClass1"));
-	assertThat([[classes objectAtIndex:1] nameOfClass], is(@"MyClass2"));
+	assertThat([classes[0] nameOfClass], is(@"MyClass1"));
+	assertThat([classes[1] nameOfClass], is(@"MyClass2"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterRootClass {
@@ -101,7 +101,7 @@
 	// verify
 	NSArray *classes = [store classesSortedByName];
 	assertThatInteger([classes count], equalToInteger(1));
-	assertThat([[classes objectAtIndex:0] nameOfClass], is(@"MyClass"));
+	assertThat([classes[0] nameOfClass], is(@"MyClass"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterClassDeclarationSourceFileAndLineNumber {
@@ -111,7 +111,7 @@
 	// execute
 	[parser parseObjectsFromString:@"@implementation MyClass @end" sourceFile:@"filename.h" toStore:store];
 	// verify
-	NSSet *files = [[[store classesSortedByName] objectAtIndex:0] sourceInfos];
+	NSSet *files = [[store classesSortedByName][0] sourceInfos];
 	assertThatInteger([files count], equalToInteger(1));
 	assertThat([[files anyObject] filename], is(@"filename.h"));
 	assertThatInteger([[files anyObject] lineNumber], equalToInteger(1));
@@ -124,7 +124,7 @@
 	// execute
 	[parser parseObjectsFromString:@"\n// cmt\n\n#define DEBUG\n\n/// hello\n@implementation MyClass @end" sourceFile:@"filename.h" toStore:store];
 	// verify
-	NSSet *files = [[[store classesSortedByName] objectAtIndex:0] sourceInfos];
+	NSSet *files = [[store classesSortedByName][0] sourceInfos];
 	assertThatInteger([[files anyObject] lineNumber], equalToInteger(7));
 }
 
@@ -137,8 +137,8 @@
 	// verify
 	NSArray *classes = [store classesSortedByName];
 	assertThatInteger([classes count], equalToInteger(2));
-	assertThat([[classes objectAtIndex:0] nameOfClass], is(@"MyClass1"));
-	assertThat([[classes objectAtIndex:1] nameOfClass], is(@"MyClass2"));
+	assertThat([classes[0] nameOfClass], is(@"MyClass1"));
+	assertThat([classes[1] nameOfClass], is(@"MyClass2"));
 }
 
 #pragma mark Class comments parsing testing
@@ -233,7 +233,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *protocols = [class.adoptedProtocols protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(1));
-	assertThat([[protocols objectAtIndex:0] nameOfProtocol], is(@"Protocol"));
+	assertThat([protocols[0] nameOfProtocol], is(@"Protocol"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterRootClassAdoptedProtocols {
@@ -246,7 +246,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *protocols = [class.adoptedProtocols protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(1));
-	assertThat([[protocols objectAtIndex:0] nameOfProtocol], is(@"Protocol"));
+	assertThat([protocols[0] nameOfProtocol], is(@"Protocol"));
 }
 
 - (void)testParseObjectsFromString_shouldIgnoreIvars {
@@ -271,7 +271,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [class.methods methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method"));
+	assertThat([methods[0] methodSelector], is(@"method"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterProperties {
@@ -284,7 +284,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [class.methods methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"name"));
+	assertThat([methods[0] methodSelector], is(@"name"));
 }
 
 #pragma mark Class declaration components parsing testing
@@ -299,7 +299,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [class.methods methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method"));
+	assertThat([methods[0] methodSelector], is(@"method"));
 }
 
 #pragma mark Merging testing
@@ -316,8 +316,8 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [class.methods methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method1"));
-	assertThat([[methods objectAtIndex:1] methodSelector], is(@"method2"));
+	assertThat([methods[0] methodSelector], is(@"method1"));
+	assertThat([methods[1] methodSelector], is(@"method2"));
 }
 
 - (void)testParseObjectsFromString_shouldMergeClassDeclarations {
@@ -332,8 +332,8 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [class.methods methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method1"));
-	assertThat([[methods objectAtIndex:1] methodSelector], is(@"method2"));
+	assertThat([methods[0] methodSelector], is(@"method1"));
+	assertThat([methods[1] methodSelector], is(@"method2"));
 }
 
 - (void)testParseObjectsFromString_shouldMergeClassDefinitionAndDeclaration {
@@ -348,8 +348,8 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [class.methods methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method1"));
-	assertThat([[methods objectAtIndex:1] methodSelector], is(@"method2"));
+	assertThat([methods[0] methodSelector], is(@"method1"));
+	assertThat([methods[1] methodSelector], is(@"method2"));
 }
 
 #pragma mark Complex parsing testing

--- a/Testing/GBObjectiveCParser-MethodsParsingTesting.m
+++ b/Testing/GBObjectiveCParser-MethodsParsingTesting.m
@@ -29,7 +29,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"id", @"method", nil];
+	[self assertMethod:methods[0] matchesInstanceComponents:@"id", @"method", nil];
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMethodDefinitionWithArguments {
@@ -42,7 +42,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"id", @"method", @"NSString", @"*", @"var", nil];
+	[self assertMethod:methods[0] matchesInstanceComponents:@"id", @"method", @"NSString", @"*", @"var", nil];
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMethodDefinitionWithMutlipleArguments {
@@ -55,7 +55,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"id", @"arg1", @"int", @"var1", @"arg2", @"long", @"var2", nil];
+	[self assertMethod:methods[0] matchesInstanceComponents:@"id", @"arg1", @"int", @"var1", @"arg2", @"long", @"var2", nil];
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMethodDefinitionBlockArgument {
@@ -68,7 +68,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"id", @"method", @"void", @"(", @"^", @")", @"(", @"id", @"obj", @",", @"NSUInteger", @"idx", @")", @"block", nil];
+	[self assertMethod:methods[0] matchesInstanceComponents:@"id", @"method", @"void", @"(", @"^", @")", @"(", @"id", @"obj", @",", @"NSUInteger", @"idx", @")", @"block", nil];
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMethodDefinitionVariableArgsArgument {
@@ -96,8 +96,8 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"id", @"method1", nil];
-	[self assertMethod:[methods objectAtIndex:1] matchesClassComponents:@"void", @"method2", nil];
+	[self assertMethod:methods[0] matchesInstanceComponents:@"id", @"method1", nil];
+	[self assertMethod:methods[1] matchesClassComponents:@"void", @"method2", nil];
 }
 
 - (void)testParseObjectsFromString_shouldHandleAttributeDirectiveForMethods {
@@ -110,7 +110,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"void", @"method", nil];
+	[self assertMethod:methods[0] matchesInstanceComponents:@"void", @"method", nil];
 }
 
 - (void)testParseObjectsFromString_shouldHandlePragmaMarkBeforeMethod {
@@ -123,8 +123,8 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"void", @"method", nil];
-	assertThat([(GBComment *)[[methods objectAtIndex:0] comment] stringValue], is(@"comment"));
+	[self assertMethod:methods[0] matchesInstanceComponents:@"void", @"method", nil];
+	assertThat([(GBComment *)[methods[0] comment] stringValue], is(@"comment"));
 }
 
 - (void)testParseObjectsFromString_shouldHandlePragmaMarkBeforeProperty {
@@ -137,8 +137,8 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesPropertyComponents:@"readonly", @"int", @"value", nil];
-	assertThat([(GBComment *)[[methods objectAtIndex:0] comment] stringValue], is(@"comment"));
+	[self assertMethod:methods[0] matchesPropertyComponents:@"readonly", @"int", @"value", nil];
+	assertThat([(GBComment *)[methods[0] comment] stringValue], is(@"comment"));
 }
 
 #pragma mark Method declarations parsing
@@ -153,7 +153,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"id", @"method", nil];
+	[self assertMethod:methods[0] matchesInstanceComponents:@"id", @"method", nil];
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMethodDeclarationWithArguments {
@@ -166,7 +166,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"id", @"method", @"NSString", @"*", @"var", nil];
+	[self assertMethod:methods[0] matchesInstanceComponents:@"id", @"method", @"NSString", @"*", @"var", nil];
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMethodDeclarationWithMutlipleArguments {
@@ -179,7 +179,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"id", @"arg1", @"int", @"var1", @"arg2", @"long", @"var2", nil];
+	[self assertMethod:methods[0] matchesInstanceComponents:@"id", @"arg1", @"int", @"var1", @"arg2", @"long", @"var2", nil];
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMethodDeclarationBlockArgument {
@@ -192,7 +192,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"id", @"method", @"void", @"(", @"^", @")", @"(", @"id", @"obj", @",", @"NSUInteger", @"idx", @")", @"block", nil];
+	[self assertMethod:methods[0] matchesInstanceComponents:@"id", @"method", @"void", @"(", @"^", @")", @"(", @"id", @"obj", @",", @"NSUInteger", @"idx", @")", @"block", nil];
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMethodDeclarationVariableArgsArgument {
@@ -220,8 +220,8 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"id", @"method1", nil];
-	[self assertMethod:[methods objectAtIndex:1] matchesClassComponents:@"void", @"method2", nil];
+	[self assertMethod:methods[0] matchesInstanceComponents:@"id", @"method1", nil];
+	[self assertMethod:methods[1] matchesClassComponents:@"void", @"method2", nil];
 }
 
 - (void)testParseObjectsFromString_shouldIgnoreMethodDeclarationSemicolon {
@@ -234,7 +234,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"id", @"method", nil];
+	[self assertMethod:methods[0] matchesInstanceComponents:@"id", @"method", nil];
 }
 
 - (void)testParseObjectsFromString_shouldIgnoreMethodDeclarationNestedCode {
@@ -247,7 +247,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesInstanceComponents:@"id", @"method", nil];
+	[self assertMethod:methods[0] matchesInstanceComponents:@"id", @"method", nil];
 }
 
 #pragma mark Properties parsing testing
@@ -262,7 +262,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesPropertyComponents:@"readonly", @"int", @"name", nil];
+	[self assertMethod:methods[0] matchesPropertyComponents:@"readonly", @"int", @"name", nil];
 }
 
 - (void)testParseObjectsFromString_shouldRegisterComplexPropertyDefinition {
@@ -275,7 +275,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesPropertyComponents:@"retain", @"nonatomic", @"IBOutlet", @"NSString", @"*", @"name", nil];
+	[self assertMethod:methods[0] matchesPropertyComponents:@"retain", @"nonatomic", @"IBOutlet", @"NSString", @"*", @"name", nil];
 }
 
 - (void)testParseObjectsFromString_shouldRegisterComplexPropertyDefinition2 {
@@ -288,7 +288,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesPropertyComponents:@"weak", @"IBOutlet", @"id", @"<", @"Protocol", @">", @"delegate", nil];
+	[self assertMethod:methods[0] matchesPropertyComponents:@"weak", @"IBOutlet", @"id", @"<", @"Protocol", @">", @"delegate", nil];
 }
 
 - (void)testParseObjectsFromString_shouldRegisterBlockPropertyDefinition {
@@ -301,7 +301,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesPropertyComponents:@"retain", @"void", @"(", @"^", @")", @"(", @"id", @",", @"NSUInteger", @")", @"name", nil];
+	[self assertMethod:methods[0] matchesPropertyComponents:@"retain", @"void", @"(", @"^", @")", @"(", @"id", @",", @"NSUInteger", @")", @"name", nil];
 }
 
 - (void)testParseObjectsFromString_shouldRegisterAllPropertyDefinitions {
@@ -314,8 +314,8 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	[self assertMethod:[methods objectAtIndex:0] matchesPropertyComponents:@"readonly", @"int", @"name1", nil];
-	[self assertMethod:[methods objectAtIndex:1] matchesPropertyComponents:@"readwrite", @"long", @"name2", nil];
+	[self assertMethod:methods[0] matchesPropertyComponents:@"readonly", @"int", @"name1", nil];
+	[self assertMethod:methods[1] matchesPropertyComponents:@"readwrite", @"long", @"name2", nil];
 }
 
 - (void)testParseObjectsFromString_shouldHandleAttributeDirectiveForProperties {
@@ -328,7 +328,7 @@
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
 	assertThatInteger([methods count], equalToInteger(1));
-	[self assertMethod:[methods objectAtIndex:0] matchesPropertyComponents:@"readonly", @"int", @"name", nil];
+	[self assertMethod:methods[0] matchesPropertyComponents:@"readonly", @"int", @"name", nil];
 }
 
 #pragma mark Methods & properties required/optional parsing
@@ -342,8 +342,8 @@
 	// verify
 	GBProtocolData *protocol = [[store protocols] anyObject];
 	NSArray *methods = [[protocol methods] methods];
-	assertThatBool([[methods objectAtIndex:0] isRequired], equalToBool(YES));
-	assertThatBool([[methods objectAtIndex:1] isRequired], equalToBool(YES));
+	assertThatBool([methods[0] isRequired], equalToBool(YES));
+	assertThatBool([methods[1] isRequired], equalToBool(YES));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterOptionalMethodDefinitionForProtocols {
@@ -355,8 +355,8 @@
 	// verify
 	GBProtocolData *protocol = [[store protocols] anyObject];
 	NSArray *methods = [[protocol methods] methods];
-	assertThatBool([[methods objectAtIndex:0] isRequired], equalToBool(NO));
-	assertThatBool([[methods objectAtIndex:1] isRequired], equalToBool(NO));
+	assertThatBool([methods[0] isRequired], equalToBool(NO));
+	assertThatBool([methods[1] isRequired], equalToBool(NO));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMixedRequiredOptionalMethodDefinitionForProtocols {
@@ -368,9 +368,9 @@
 	// verify
 	GBProtocolData *protocol = [[store protocols] anyObject];
 	NSArray *methods = [[protocol methods] methods];
-	assertThatBool([[methods objectAtIndex:0] isRequired], equalToBool(YES));
-	assertThatBool([[methods objectAtIndex:1] isRequired], equalToBool(NO));
-	assertThatBool([[methods objectAtIndex:2] isRequired], equalToBool(YES));
+	assertThatBool([methods[0] isRequired], equalToBool(YES));
+	assertThatBool([methods[1] isRequired], equalToBool(NO));
+	assertThatBool([methods[2] isRequired], equalToBool(YES));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterRequiredPropertyDefinitionForProtocols {
@@ -382,8 +382,8 @@
 	// verify
 	GBProtocolData *protocol = [[store protocols] anyObject];
 	NSArray *methods = [[protocol methods] methods];
-	assertThatBool([[methods objectAtIndex:0] isRequired], equalToBool(YES));
-	assertThatBool([[methods objectAtIndex:1] isRequired], equalToBool(YES));
+	assertThatBool([methods[0] isRequired], equalToBool(YES));
+	assertThatBool([methods[1] isRequired], equalToBool(YES));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterOptionalPropertyDefinitionForProtocols {
@@ -395,8 +395,8 @@
 	// verify
 	GBProtocolData *protocol = [[store protocols] anyObject];
 	NSArray *methods = [[protocol methods] methods];
-	assertThatBool([[methods objectAtIndex:0] isRequired], equalToBool(NO));
-	assertThatBool([[methods objectAtIndex:1] isRequired], equalToBool(NO));
+	assertThatBool([methods[0] isRequired], equalToBool(NO));
+	assertThatBool([methods[1] isRequired], equalToBool(NO));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMixedRequiredOptionalPropertyDefinitionForProtocols {
@@ -408,9 +408,9 @@
 	// verify
 	GBProtocolData *protocol = [[store protocols] anyObject];
 	NSArray *methods = [[protocol methods] methods];
-	assertThatBool([[methods objectAtIndex:0] isRequired], equalToBool(YES));
-	assertThatBool([[methods objectAtIndex:1] isRequired], equalToBool(NO));
-	assertThatBool([[methods objectAtIndex:2] isRequired], equalToBool(YES));
+	assertThatBool([methods[0] isRequired], equalToBool(YES));
+	assertThatBool([methods[1] isRequired], equalToBool(NO));
+	assertThatBool([methods[2] isRequired], equalToBool(YES));
 }
 
 #pragma mark Methods & properties extras parsing
@@ -504,8 +504,8 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1"));
-	assertThat([[(GBModelBase *)[methods objectAtIndex:1] comment] stringValue], is(@"Comment2"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1"));
+	assertThat([[(GBModelBase *) methods[1] comment] stringValue], is(@"Comment2"));
 }
 
 - (void)testParseObjectsFromString_shouldProperlyResetMethodComments {
@@ -517,8 +517,8 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1"));
-	assertThat([(GBModelBase *)[methods objectAtIndex:1] comment], is(nil));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1"));
+	assertThat([(GBModelBase *) methods[1] comment], is(nil));
 }
 
 - (void)testParseObjectsFromString_shouldProperlyResetPropertyComments {
@@ -530,8 +530,8 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1"));
-	assertThat([(GBModelBase *)[methods objectAtIndex:1] comment], is(nil));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1"));
+	assertThat([(GBModelBase *) methods[1] comment], is(nil));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMethodDeclarationComment {
@@ -543,8 +543,8 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1"));
-	assertThat([[(GBModelBase *)[methods objectAtIndex:1] comment] stringValue], is(@"Comment2"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1"));
+	assertThat([[(GBModelBase *) methods[1] comment] stringValue], is(@"Comment2"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterPropertyDefinitionComment {
@@ -556,8 +556,8 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1"));
-	assertThat([[(GBModelBase *)[methods objectAtIndex:1] comment] stringValue], is(@"Comment2"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1"));
+	assertThat([[(GBModelBase *) methods[1] comment] stringValue], is(@"Comment2"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMethodDefinitionCommentSourceFileAndLineNumber {
@@ -568,7 +568,7 @@
 	[parser parseObjectsFromString:@"/// comment\n\n#define SOMETHING\n\n@interface MyClass\n/** comment */\n-(void)method; @end" sourceFile:@"filename.h" toStore:store];
 	// verify
 	GBClassData *class = [[store classes] anyObject];
-	GBMethodData *method = [[[class methods] methods] objectAtIndex:0];
+	GBMethodData *method = [[class methods] methods][0];
 	assertThat(method.comment.sourceInfo.filename, is(@"filename.h"));
 	assertThatInteger(method.comment.sourceInfo.lineNumber, equalToInteger(6));
 }
@@ -581,7 +581,7 @@
 	[parser parseObjectsFromString:@"/// comment\n\n#define SOMETHING\n\n@implementation MyClass\n/** comment */\n-(void)method{} @end" sourceFile:@"filename.h" toStore:store];
 	// verify
 	GBClassData *class = [[store classes] anyObject];
-	GBMethodData *method = [[[class methods] methods] objectAtIndex:0];
+	GBMethodData *method = [[class methods] methods][0];
 	assertThat(method.comment.sourceInfo.filename, is(@"filename.h"));
 	assertThatInteger(method.comment.sourceInfo.lineNumber, equalToInteger(6));
 }
@@ -594,7 +594,7 @@
 	[parser parseObjectsFromString:@"/// comment\n\n#define SOMETHING\n\n@interface MyClass\n/** comment */\n@property(readonly)int p1; @end" sourceFile:@"filename.h" toStore:store];
 	// verify
 	GBClassData *class = [[store classes] anyObject];
-	GBMethodData *method = [[[class methods] methods] objectAtIndex:0];
+	GBMethodData *method = [[class methods] methods][0];
 	assertThat(method.comment.sourceInfo.filename, is(@"filename.h"));
 	assertThatInteger(method.comment.sourceInfo.lineNumber, equalToInteger(6));
 }
@@ -624,11 +624,11 @@
    GBEnumConstantProvider *constantsProvider = [enumData constants];
    NSArray *constants = [constantsProvider constants];
 
-	assertThat([[(GBModelBase *)[constants objectAtIndex:0] comment] stringValue], is(@"postfix1"));
-	assertThat([[(GBModelBase *)[constants objectAtIndex:1] comment] stringValue], is(@"postfix2"));
-	assertThat([[(GBModelBase *)[constants objectAtIndex:2] comment] stringValue], is(@"comment3"));
-	assertThat([[(GBModelBase *)[constants objectAtIndex:3] comment] stringValue], is(@"comment4"));
-	assertThat([[(GBModelBase *)[constants objectAtIndex:4] comment] stringValue], is(@"comment5"));
+	assertThat([[(GBModelBase *) constants[0] comment] stringValue], is(@"postfix1"));
+	assertThat([[(GBModelBase *) constants[1] comment] stringValue], is(@"postfix2"));
+	assertThat([[(GBModelBase *) constants[2] comment] stringValue], is(@"comment3"));
+	assertThat([[(GBModelBase *) constants[3] comment] stringValue], is(@"comment4"));
+	assertThat([[(GBModelBase *) constants[4] comment] stringValue], is(@"comment5"));
 	assertThatInteger([constants count], equalToInteger(5));
 }
 
@@ -655,11 +655,11 @@
    GBEnumConstantProvider *constantsProvider = [optionData constants];
    NSArray *constants = [constantsProvider constants];
 
-	assertThat([[(GBModelBase *)[constants objectAtIndex:0] comment] stringValue], is(@"postfix1"));
-	assertThat([[(GBModelBase *)[constants objectAtIndex:1] comment] stringValue], is(@"postfix2"));
-	assertThat([[(GBModelBase *)[constants objectAtIndex:2] comment] stringValue], is(@"comment3"));
-	assertThat([[(GBModelBase *)[constants objectAtIndex:3] comment] stringValue], is(@"comment4"));
-	assertThat([[(GBModelBase *)[constants objectAtIndex:4] comment] stringValue], is(@"comment5"));
+	assertThat([[(GBModelBase *) constants[0] comment] stringValue], is(@"postfix1"));
+	assertThat([[(GBModelBase *) constants[1] comment] stringValue], is(@"postfix2"));
+	assertThat([[(GBModelBase *) constants[2] comment] stringValue], is(@"comment3"));
+	assertThat([[(GBModelBase *) constants[3] comment] stringValue], is(@"comment4"));
+	assertThat([[(GBModelBase *) constants[4] comment] stringValue], is(@"comment5"));
 	assertThatInteger([constants count], equalToInteger(5));
 }
 
@@ -673,8 +673,8 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1"));
-	assertThat([[(GBModelBase *)[methods objectAtIndex:1] comment] stringValue], is(@"Comment2"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1"));
+	assertThat([[(GBModelBase *) methods[1] comment] stringValue], is(@"Comment2"));
 	assertThatInteger([methods count], equalToInteger(2));
 }
 
@@ -687,8 +687,8 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1"));
-	assertThat([[(GBModelBase *)[methods objectAtIndex:1] comment] stringValue], is(@"Comment2"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1"));
+	assertThat([[(GBModelBase *) methods[1] comment] stringValue], is(@"Comment2"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMethodDeclarationPostfixCommentProperSourceLineNumber {
@@ -699,7 +699,7 @@
 	[parser parseObjectsFromString:@"/// comment\n\n#define SOMETHING\n\n@implementation MyClass\n-(void)method ///< comment\n{} @end" sourceFile:@"filename.h" toStore:store];
 	// verify
 	GBClassData *class = [[store classes] anyObject];
-	GBMethodData *method = [[[class methods] methods] objectAtIndex:0];
+	GBMethodData *method = [[class methods] methods][0];
 	assertThat(method.comment.sourceInfo.filename, is(@"filename.h"));
 	assertThatInteger(method.comment.sourceInfo.lineNumber, equalToInteger(6));
 }
@@ -713,7 +713,7 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1\nComment2"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1\nComment2"));
 	assertThatInteger([methods count], equalToInteger(1));
 }
 
@@ -726,7 +726,7 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1\nComment2\nComment3"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1\nComment2\nComment3"));
 	assertThatInteger([methods count], equalToInteger(1));
 }
 
@@ -738,7 +738,7 @@
    [parser parseObjectsFromString:@"@implementation MyClass\n -(id)method1:(id)param1 ///< Comment1\npart2:(id)param2 ///< Comment2\n{}\n@end" sourceFile:@"filename.m" toStore:store];
 	// verify
 	GBClassData *class = [[store classes] anyObject];
-	GBMethodData *method = [[[class methods] methods] objectAtIndex:0];
+	GBMethodData *method = [[class methods] methods][0];
 	assertThat(method.comment.sourceInfo.filename, is(@"filename.m"));
 	assertThatInteger(method.comment.sourceInfo.lineNumber, equalToInteger(2));
 }
@@ -753,8 +753,8 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1"));
-	assertThat([[(GBModelBase *)[methods objectAtIndex:1] comment] stringValue], is(@"Comment2"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1"));
+	assertThat([[(GBModelBase *) methods[1] comment] stringValue], is(@"Comment2"));
 	assertThatInteger([methods count], equalToInteger(2));
 }
 
@@ -767,8 +767,8 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1"));
-	assertThat([[(GBModelBase *)[methods objectAtIndex:1] comment] stringValue], is(@"Comment2"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1"));
+	assertThat([[(GBModelBase *) methods[1] comment] stringValue], is(@"Comment2"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMethodDefinitionPostfixCommentSourceFileAndLineNumber {
@@ -779,7 +779,7 @@
 	[parser parseObjectsFromString:@"/// comment\n\n#define SOMETHING\n\n@interface MyClass\n-(void)method; ///< Comment1\n @end" sourceFile:@"filename.h" toStore:store];
 	// verify
 	GBClassData *class = [[store classes] anyObject];
-	GBMethodData *method = [[[class methods] methods] objectAtIndex:0];
+	GBMethodData *method = [[class methods] methods][0];
 	assertThat(method.comment.sourceInfo.filename, is(@"filename.h"));
 	assertThatInteger(method.comment.sourceInfo.lineNumber, equalToInteger(6));
 }
@@ -793,7 +793,7 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1\nComment2"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1\nComment2"));
 	assertThatInteger([methods count], equalToInteger(1));
 }
 
@@ -806,7 +806,7 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1\nComment2\nComment3\nComment4"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1\nComment2\nComment3\nComment4"));
 	assertThatInteger([methods count], equalToInteger(1));
 }
 
@@ -818,7 +818,7 @@
    [parser parseObjectsFromString:@"///< comment\n/// comment\n#define SOMETHING\n\n@interface MyClass\n -(id)method1:(id)param1 ///< Comment1\npart2:(id)param2 ///< Comment2\n;\n@end" sourceFile:@"filename.h" toStore:store];
 	// verify
 	GBClassData *class = [[store classes] anyObject];
-	GBMethodData *method = [[[class methods] methods] objectAtIndex:0];
+	GBMethodData *method = [[class methods] methods][0];
 	assertThat(method.comment.sourceInfo.filename, is(@"filename.h"));
 	assertThatInteger(method.comment.sourceInfo.lineNumber, equalToInteger(6));
 }
@@ -833,8 +833,8 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"Comment1"));
-	assertThat([[(GBModelBase *)[methods objectAtIndex:1] comment] stringValue], is(@"Comment2"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"Comment1"));
+	assertThat([[(GBModelBase *) methods[1] comment] stringValue], is(@"Comment2"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterPropertyDefinitionPostfixCommentLong {
@@ -846,7 +846,7 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"postfix1\npostfix2\npostfix3\npostfix4\npostfix5"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"postfix1\npostfix2\npostfix3\npostfix4\npostfix5"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterPropertyDefinitionPostfixCommentSourceFileAndLineNumber {
@@ -857,7 +857,7 @@
 	[parser parseObjectsFromString:@"/// comment\n\n#define SOMETHING\n\n@interface MyClass\n@property(readonly)int p1;///< comment\n @end" sourceFile:@"filename.h" toStore:store];
 	// verify
 	GBClassData *class = [[store classes] anyObject];
-	GBMethodData *method = [[[class methods] methods] objectAtIndex:0];
+	GBMethodData *method = [[class methods] methods][0];
 	assertThat(method.comment.sourceInfo.filename, is(@"filename.h"));
 	assertThatInteger(method.comment.sourceInfo.lineNumber, equalToInteger(6));
 }
@@ -871,7 +871,7 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"prefix"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"prefix"));
 	assertThatInteger([methods count], equalToInteger(1));
 }
 
@@ -884,7 +884,7 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"inside"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"inside"));
 	assertThatInteger([methods count], equalToInteger(1));
 }
 
@@ -897,7 +897,7 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	assertThat([[(GBModelBase *)[methods objectAtIndex:0] comment] stringValue], is(@"inside\nafter"));
+	assertThat([[(GBModelBase *) methods[0] comment] stringValue], is(@"inside\nafter"));
 	assertThatInteger([methods count], equalToInteger(1));
 }
 
@@ -918,7 +918,7 @@
 	// verify
 	GBClassData *class = [[store classes] anyObject];
 	NSArray *methods = [[class methods] methods];
-	GBMethodData *method = [methods objectAtIndex:0];
+	GBMethodData *method = methods[0];
 	assertThatInteger([methods count], equalToInteger(1));
 	[self assertMethod:method matchesInstanceComponents:@"void", @"method", nil];	
 	assertThat(method.comment.stringValue, is(@"comment"));

--- a/Testing/GBObjectiveCParser-ProtocolParsingTesting.m
+++ b/Testing/GBObjectiveCParser-ProtocolParsingTesting.m
@@ -28,7 +28,7 @@
 	// verify
 	NSArray *protocols = [store protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(1));
-	assertThat([[protocols objectAtIndex:0] nameOfProtocol], is(@"MyProtocol"));
+	assertThat([protocols[0] nameOfProtocol], is(@"MyProtocol"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterProtocolSourceFileAndLineNumber {
@@ -38,7 +38,7 @@
 	// execute
 	[parser parseObjectsFromString:@"@protocol MyProtocol @end" sourceFile:@"filename.h" toStore:store];
 	// verify
-	NSSet *files = [[[store protocolsSortedByName] objectAtIndex:0] sourceInfos];
+	NSSet *files = [[store protocolsSortedByName][0] sourceInfos];
 	assertThatInteger([files count], equalToInteger(1));
 	assertThat([[files anyObject] filename], is(@"filename.h"));
 	assertThatInteger([[files anyObject] lineNumber], equalToInteger(1));
@@ -51,7 +51,7 @@
 	// execute
 	[parser parseObjectsFromString:@"\n// cmt\n\n#define DEBUG\n\n/// hello\n@protocol MyProtocol @end" sourceFile:@"filename.h" toStore:store];
 	// verify
-	NSSet *files = [[[store protocolsSortedByName] objectAtIndex:0] sourceInfos];
+	NSSet *files = [[store protocolsSortedByName][0] sourceInfos];
 	assertThatInteger([[files anyObject] lineNumber], equalToInteger(7));
 }
 
@@ -64,8 +64,8 @@
 	// verify
 	NSArray *protocols = [store protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(2));
-	assertThat([[protocols objectAtIndex:0] nameOfProtocol], is(@"MyProtocol1"));
-	assertThat([[protocols objectAtIndex:1] nameOfProtocol], is(@"MyProtocol2"));
+	assertThat([protocols[0] nameOfProtocol], is(@"MyProtocol1"));
+	assertThat([protocols[1] nameOfProtocol], is(@"MyProtocol2"));
 }
 
 #pragma mark Protocol comments parsing testing
@@ -136,8 +136,8 @@
 	GBProtocolData *protocol = [[store protocols] anyObject];
 	NSArray *protocols = [protocol.adoptedProtocols protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(2));
-	assertThat([[protocols objectAtIndex:0] nameOfProtocol], is(@"Protocol1"));
-	assertThat([[protocols objectAtIndex:1] nameOfProtocol], is(@"Protocol2"));
+	assertThat([protocols[0] nameOfProtocol], is(@"Protocol1"));
+	assertThat([protocols[1] nameOfProtocol], is(@"Protocol2"));
 }
 
 - (void)testParseObjectsFromString_shouldRegisterMethods {
@@ -150,8 +150,8 @@
 	GBProtocolData *protocol = [[store protocols] anyObject];
 	NSArray *methods = [protocol.methods methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method1"));
-	assertThat([[methods objectAtIndex:1] methodSelector], is(@"method2"));
+	assertThat([methods[0] methodSelector], is(@"method1"));
+	assertThat([methods[1] methodSelector], is(@"method2"));
 }
 
 #pragma mark Merging testing
@@ -168,8 +168,8 @@
 	GBProtocolData *protocol = [[store protocols] anyObject];
 	NSArray *methods = [protocol.methods methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	assertThat([[methods objectAtIndex:0] methodSelector], is(@"method1"));
-	assertThat([[methods objectAtIndex:1] methodSelector], is(@"method2"));
+	assertThat([methods[0] methodSelector], is(@"method1"));
+	assertThat([methods[1] methodSelector], is(@"method2"));
 }
 
 #pragma mark Complex parsing testing

--- a/Testing/GBObjectiveCParser-SectionsParsingTesting.m
+++ b/Testing/GBObjectiveCParser-SectionsParsingTesting.m
@@ -26,11 +26,11 @@
 	// verify
 	NSArray *sections = [[[[store classes] anyObject] methods] sections];
 	assertThatInteger([sections count], equalToInteger(1));
-	GBMethodSectionData *section = [sections objectAtIndex:0];
+	GBMethodSectionData *section = sections[0];
 	assertThat(section.sectionName, is(@"Section1"));
 	assertThatInteger([[section methods] count], equalToInteger(2));
-	[self assertMethod:[[section methods] objectAtIndex:0] matchesInstanceComponents:@"id", @"method1", nil];
-	[self assertMethod:[[section methods] objectAtIndex:1] matchesInstanceComponents:@"id", @"method2", nil];
+	[self assertMethod:[section methods][0] matchesInstanceComponents:@"id", @"method1", nil];
+	[self assertMethod:[section methods][1] matchesInstanceComponents:@"id", @"method2", nil];
 }
 
 - (void)testParseObjectsFromString_shouldRegisterUncommentedMethodsToLastSection {
@@ -42,11 +42,11 @@
 	// verify
 	NSArray *sections = [[[[store classes] anyObject] methods] sections];
 	assertThatInteger([sections count], equalToInteger(1));
-	GBMethodSectionData *section = [sections objectAtIndex:0];
+	GBMethodSectionData *section = sections[0];
 	assertThat(section.sectionName, is(@"Section1"));
 	assertThatInteger([[section methods] count], equalToInteger(2));
-	[self assertMethod:[[section methods] objectAtIndex:0] matchesInstanceComponents:@"id", @"method1", nil];
-	[self assertMethod:[[section methods] objectAtIndex:1] matchesInstanceComponents:@"id", @"method2", nil];
+	[self assertMethod:[section methods][0] matchesInstanceComponents:@"id", @"method1", nil];
+	[self assertMethod:[section methods][1] matchesInstanceComponents:@"id", @"method2", nil];
 }
 
 - (void)testParseObjectsFromString_shouldDetectLongSectionNames {
@@ -58,7 +58,7 @@
 	// verify
 	NSArray *sections = [[[[store classes] anyObject] methods] sections];
 	assertThatInteger([sections count], equalToInteger(1));
-	assertThat([[sections objectAtIndex:0] sectionName], is(@"Long section name"));
+	assertThat([sections[0] sectionName], is(@"Long section name"));
 }
 
 - (void)testParseObjectsFromString_shouldDetectSectionNameOnlyIfAtStartOfComment {
@@ -70,7 +70,7 @@
 	// verify - note that we still create default section!
 	NSArray *sections = [[[[store classes] anyObject] methods] sections];
 	assertThatInteger([sections count], equalToInteger(1));
-	assertThat([[sections objectAtIndex:0] sectionName], is(nil));
+	assertThat([sections[0] sectionName], is(nil));
 }
 
 - (void)testParseObjectsFromString_shouldOnlyTakeSectionNameFromTheFirstLineString {
@@ -82,7 +82,7 @@
 	// verify
 	NSArray *sections = [[[[store classes] anyObject] methods] sections];
 	assertThatInteger([sections count], equalToInteger(1));
-	assertThat([[sections objectAtIndex:0] sectionName], is(@"Section"));
+	assertThat([sections[0] sectionName], is(@"Section"));
 }
 
 - (void)testParseObjectsFromString_requiresDetectsSectionEvenIfFollowedByUncommentedMethod {
@@ -94,10 +94,10 @@
 	// verify
 	NSArray *sections = [[[[store classes] anyObject] methods] sections];
 	assertThatInteger([sections count], equalToInteger(1));
-	GBMethodSectionData *section = [sections objectAtIndex:0];
+	GBMethodSectionData *section = sections[0];
 	assertThat(section.sectionName, is(@"Section"));
 	assertThatInteger([section.methods count], equalToInteger(1));
-	assertThat([[section.methods objectAtIndex:0] comment], is(nil));
+	assertThat([section.methods[0] comment], is(nil));
 }
 
 - (void)testParseObjectsFromString_shouldDetectSectionAndCommentForNextCommentedMethod {
@@ -109,11 +109,11 @@
 	// verify
 	NSArray *sections = [[[[store classes] anyObject] methods] sections];
 	assertThatInteger([sections count], equalToInteger(1));
-	GBMethodSectionData *section = [sections objectAtIndex:0];
+	GBMethodSectionData *section = sections[0];
 	assertThat(section.sectionName, is(@"Section1"));
 	assertThatInteger([section.methods count], equalToInteger(2));
-	assertThat([[section.methods objectAtIndex:0] comment], is(nil));
-	assertThat([(GBComment *)[[section.methods objectAtIndex:1] comment] stringValue], is(@"Second"));
+	assertThat([section.methods[0] comment], is(nil));
+	assertThat([(GBComment *)[section.methods[1] comment] stringValue], is(@"Second"));
 }
 
 @end

--- a/Testing/GBProcessor-CategoriesMergingTesting.m
+++ b/Testing/GBProcessor-CategoriesMergingTesting.m
@@ -82,8 +82,8 @@
 	// verify
 	NSArray *methods = [class.methods methods];
 	assertThatInteger([methods count], equalToInteger(2));
-	assertThatBool([methods containsObject:[category.methods.methods objectAtIndex:0]], equalToBool(YES));
-	assertThatBool([methods containsObject:[extension.methods.methods objectAtIndex:0]], equalToBool(YES));
+	assertThatBool([methods containsObject:category.methods.methods[0]], equalToBool(YES));
+	assertThatBool([methods containsObject:extension.methods.methods[0]], equalToBool(YES));
 }
 
 - (void)testProcessObjectsFromStore_shouldUseRegisterMethodOnClassToMergeMethods {
@@ -93,7 +93,7 @@
 	[category.methods registerMethod:[GBTestObjectsRegistry instanceMethodWithNames:@"method", nil]];
 	OCMockObject *class = [OCMockObject niceMockForClass:[GBClassData class]];
 	OCMockObject *provider = [OCMockObject niceMockForClass:[GBMethodsProvider class]];
-	[[provider expect] registerMethod:[category.methods.methods objectAtIndex:0]];
+	[[provider expect] registerMethod:category.methods.methods[0]];
 	[[[class stub] andReturn:@"Class"] nameOfClass];
 	[[[class stub] andReturn:provider] methods];
 	GBStore *store = [GBTestObjectsRegistry storeWithObjects:class, category, nil];
@@ -120,9 +120,9 @@
 	// verify
 	NSArray *sections = [class.methods sections];
 	assertThatInteger([sections count], equalToInteger(2));
-	GBMethodSectionData *section = [sections objectAtIndex:1];
+	GBMethodSectionData *section = sections[1];
 	assertThatInteger([section.methods count], equalToInteger(1));
-	assertThatBool([section.methods containsObject:[category.methods.methods objectAtIndex:0]], equalToBool(YES)); 
+	assertThatBool([section.methods containsObject:category.methods.methods[0]], equalToBool(YES));
 }
 
 - (void)testProcessObjectsFromStore_shouldCreateSingleSectionIfKeepSectionsIsNo {
@@ -140,10 +140,10 @@
 	// verify
 	NSArray *sections = [class.methods sections];
 	assertThatInteger([sections count], equalToInteger(1));
-	GBMethodSectionData *section = [sections objectAtIndex:0];
+	GBMethodSectionData *section = sections[0];
 	assertThatInteger([section.methods count], equalToInteger(2));
-	assertThatBool([section.methods containsObject:[category.methods.methods objectAtIndex:0]], equalToBool(YES)); 
-	assertThatBool([section.methods containsObject:[category.methods.methods objectAtIndex:1]], equalToBool(YES));
+	assertThatBool([section.methods containsObject:category.methods.methods[0]], equalToBool(YES));
+	assertThatBool([section.methods containsObject:category.methods.methods[1]], equalToBool(YES));
 }
 
 - (void)testProcessObjectsFromStore_shouldDuplicateSectionsIfKeepSectionsIsYes {
@@ -162,12 +162,12 @@
 	GBMethodSectionData *section;
 	NSArray *sections = [class.methods sections];
 	assertThatInteger([sections count], equalToInteger(2));
-	section = [sections objectAtIndex:0];
+	section = sections[0];
 	assertThatInteger([section.methods count], equalToInteger(1));
-	assertThatBool([section.methods containsObject:[category.methods.methods objectAtIndex:0]], equalToBool(YES)); 
-	section = [sections objectAtIndex:1];
+	assertThatBool([section.methods containsObject:category.methods.methods[0]], equalToBool(YES));
+	section = sections[1];
 	assertThatInteger([section.methods count], equalToInteger(1));
-	assertThatBool([section.methods containsObject:[category.methods.methods objectAtIndex:1]], equalToBool(YES));
+	assertThatBool([section.methods containsObject:category.methods.methods[1]], equalToBool(YES));
 }
 
 #pragma mark Section naming testing
@@ -182,7 +182,7 @@
 	// execute
 	[processor processObjectsFromStore:store];
 	// verify
-	NSString *name = [[class.methods.sections objectAtIndex:0] sectionName];
+	NSString *name = [class.methods.sections[0] sectionName];
 	assertThatBool([name rangeOfString:category.nameOfCategory].location != NSNotFound, equalToBool(YES));
 }
 
@@ -197,7 +197,7 @@
 	// execute
 	[processor processObjectsFromStore:store];
 	// verify
-	assertThat([[class.methods.sections objectAtIndex:0] sectionName], is(@"Section"));
+	assertThat([class.methods.sections[0] sectionName], is(@"Section"));
 }
 
 - (void)testProcessObjectsFromStore_shouldAddCategoryNameToSectionNamesIfPrefixIsYes {
@@ -211,7 +211,7 @@
 	// execute
 	[processor processObjectsFromStore:store];
 	// verify
-	NSString *name = [[class.methods.sections objectAtIndex:0] sectionName];
+	NSString *name = [class.methods.sections[0] sectionName];
 	assertThatBool([name rangeOfString:@"Section"].location != NSNotFound, equalToBool(YES));
 	assertThatBool([name rangeOfString:category.nameOfCategory].location != NSNotFound, equalToBool(YES));
 }
@@ -227,16 +227,16 @@
 	// execute
 	[processor processObjectsFromStore:store];
 	// verify
-	assertThat([[class.methods.sections objectAtIndex:0] sectionName], is(@"Section"));
+	assertThat([class.methods.sections[0] sectionName], is(@"Section"));
 }
 
 #pragma mark Creation methods
 
 - (GBProcessor *)processorWithMerge:(BOOL)merge keep:(BOOL)keep prefix:(BOOL)prefix {
 	OCMockObject *settings = [GBTestObjectsRegistry mockSettingsProvider];
-	[[[settings stub] andReturnValue:[NSNumber numberWithBool:merge]] mergeCategoriesToClasses];
-	[[[settings stub] andReturnValue:[NSNumber numberWithBool:keep]] keepMergedCategoriesSections];
-	[[[settings stub] andReturnValue:[NSNumber numberWithBool:prefix]] prefixMergedCategoriesSectionsWithCategoryName];
+	[[[settings stub] andReturnValue:@(merge)] mergeCategoriesToClasses];
+	[[[settings stub] andReturnValue:@(keep)] keepMergedCategoriesSections];
+	[[[settings stub] andReturnValue:@(prefix)] prefixMergedCategoriesSectionsWithCategoryName];
 	[GBTestObjectsRegistry settingsProvider:settings keepObjects:YES keepMembers:YES];
 	return [GBProcessor processorWithSettingsProvider:settings];
 }

--- a/Testing/GBProcessor-CommentsTesting.m
+++ b/Testing/GBProcessor-CommentsTesting.m
@@ -195,7 +195,7 @@
 
 - (OCMockObject *)mockSettingsProviderRepeatFirst:(BOOL)repeat {
 	OCMockObject *result = [GBTestObjectsRegistry mockSettingsProvider];
-	[[[result stub] andReturnValue:[NSNumber numberWithBool:repeat]] repeatFirstParagraphForMemberDescription];
+	[[[result stub] andReturnValue:@(repeat)] repeatFirstParagraphForMemberDescription];
 	return result;
 }
 

--- a/Testing/GBProcessor-KnownObjectsTesting.m
+++ b/Testing/GBProcessor-KnownObjectsTesting.m
@@ -40,8 +40,8 @@
 	// verify
 	NSArray *protocols = [class.adoptedProtocols protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(2));
-	assertThat([protocols objectAtIndex:0], is(realProtocol));
-	assertThat([protocols objectAtIndex:1], is(adoptedProtocol2));
+	assertThat(protocols[0], is(realProtocol));
+	assertThat(protocols[1], is(adoptedProtocol2));
 }
 
 - (void)testProcessObjectsFromStore_shouldReplaceKnownCategoryAdoptedProtocolsWithProtocolsFromStore {
@@ -61,8 +61,8 @@
 	// verify
 	NSArray *protocols = [category.adoptedProtocols protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(2));
-	assertThat([protocols objectAtIndex:0], is(realProtocol));
-	assertThat([protocols objectAtIndex:1], is(adoptedProtocol2));
+	assertThat(protocols[0], is(realProtocol));
+	assertThat(protocols[1], is(adoptedProtocol2));
 }
 
 - (void)testProcessObjectsFromStore_shouldReplaceKnownProtocolAdoptedProtocolsWithProtocolsFromStore {
@@ -82,8 +82,8 @@
 	// verify
 	NSArray *protocols = [protocol.adoptedProtocols protocolsSortedByName];
 	assertThatInteger([protocols count], equalToInteger(2));
-	assertThat([protocols objectAtIndex:0], is(realProtocol));
-	assertThat([protocols objectAtIndex:1], is(adoptedProtocol2));
+	assertThat(protocols[0], is(realProtocol));
+	assertThat(protocols[1], is(adoptedProtocol2));
 }
 
 #pragma mark Subclasses handling

--- a/Testing/GBProcessor-MemberDocCopyingTesting.m
+++ b/Testing/GBProcessor-MemberDocCopyingTesting.m
@@ -149,9 +149,9 @@
 
 - (GBProcessor *)processorWithFind:(BOOL)find keepObjects:(BOOL)objects keepMembers:(BOOL)members {
 	OCMockObject *settings = [GBTestObjectsRegistry mockSettingsProvider];
-	[[[settings stub] andReturnValue:[NSNumber numberWithBool:find]] findUndocumentedMembersDocumentation];
-	[[[settings stub] andReturnValue:[NSNumber numberWithBool:objects]] keepUndocumentedObjects];
-	[[[settings stub] andReturnValue:[NSNumber numberWithBool:members]] keepUndocumentedMembers];
+	[[[settings stub] andReturnValue:@(find)] findUndocumentedMembersDocumentation];
+	[[[settings stub] andReturnValue:@(objects)] keepUndocumentedObjects];
+	[[[settings stub] andReturnValue:@(members)] keepUndocumentedMembers];
 	[GBTestObjectsRegistry settingsProvider:settings keepObjects:YES keepMembers:YES];
 	return [GBProcessor processorWithSettingsProvider:settings];
 }

--- a/Testing/GBProcessor-UndocumentedObjectsTesting.m
+++ b/Testing/GBProcessor-UndocumentedObjectsTesting.m
@@ -92,7 +92,7 @@
 	// verify
 	NSArray *methods = [class.methods methods];
  	assertThatInteger([methods count], equalToInteger(1));
-	assertThatBool([methods containsObject:[uncommented objectAtIndex:0]], equalToBool(YES));
+	assertThatBool([methods containsObject:uncommented[0]], equalToBool(YES));
 }
 
 - (void)testProcessObjectsFromStore_shouldDeleteUncommentedMethodsIfKeepMembersIsNo {
@@ -107,8 +107,8 @@
 	// verify
 	NSArray *methods = [class.methods methods];
  	assertThatInteger([methods count], equalToInteger(1));
-	assertThatBool([methods containsObject:[commented objectAtIndex:0]], equalToBool(YES));
-	assertThatBool([methods containsObject:[uncommented objectAtIndex:0]], equalToBool(NO));
+	assertThatBool([methods containsObject:commented[0]], equalToBool(YES));
+	assertThatBool([methods containsObject:uncommented[0]], equalToBool(NO));
 }
 
 - (void)testProcessObjectsFromStore_shouldKeepUncommentedObjectIfAllMethodsAreUnregisteredIfKeepObjectIsYes {

--- a/Testing/GBStoreTesting.m
+++ b/Testing/GBStoreTesting.m
@@ -25,7 +25,7 @@
 	// verify
 	assertThatBool([store.classes containsObject:class], equalToBool(YES));
 	assertThatInteger([[store.classes allObjects] count], equalToInteger(1));
-	assertThat([[store.classes allObjects] objectAtIndex:0], is(class));
+	assertThat([store.classes allObjects][0], is(class));
 }
 
 - (void)testRegisterClass_shouldIgnoreSameInstance {
@@ -80,7 +80,7 @@
 	// verify
 	assertThatBool([store.categories containsObject:category], equalToBool(YES));
 	assertThatInteger([[store.categories allObjects] count], equalToInteger(1));
-	assertThat([[store.categories allObjects] objectAtIndex:0], is(category));
+	assertThat([store.categories allObjects][0], is(category));
 }
 
 - (void)testRegisterCategory_shouldIgnoreSameInstance {
@@ -119,7 +119,7 @@
 	// verify
 	assertThatBool([store.categories containsObject:extension], equalToBool(YES));
 	assertThatInteger([[store.categories allObjects] count], equalToInteger(1));
-	assertThat([[store.categories allObjects] objectAtIndex:0], is(extension));
+	assertThat([store.categories allObjects][0], is(extension));
 }
 
 - (void)testRegisterExtension_shouldIgnoreSameInstance {
@@ -192,7 +192,7 @@
 	// verify
 	assertThatBool([store.protocols containsObject:protocol], equalToBool(YES));
 	assertThatInteger([[store.protocols allObjects] count], equalToInteger(1));
-	assertThat([[store.protocols allObjects] objectAtIndex:0], is(protocol));
+	assertThat([store.protocols allObjects][0], is(protocol));
 }
 
 - (void)testRegisterProtocol_shouldIgnoreSameInstance {
@@ -247,7 +247,7 @@
 	// verify
 	assertThatBool([store.documents containsObject:document], equalToBool(YES));
 	assertThatInteger([[store.documents allObjects] count], equalToInteger(1));
-	assertThat([[store.documents allObjects] objectAtIndex:0], is(document));
+	assertThat([store.documents allObjects][0], is(document));
 }
 
 - (void)testRegisterDocument_shouldIgnoreSameInstance {

--- a/Testing/GBTemplateHandlerTesting.m
+++ b/Testing/GBTemplateHandlerTesting.m
@@ -69,7 +69,7 @@
 	// verify
 	assertThatBool(result, equalToBool(YES));
 	assertThatInteger([loader.templateSections count], equalToInteger(1));
-	assertThat([loader.templateSections objectForKey:@"name"], is(@"text"));
+	assertThat(loader.templateSections[@"name"], is(@"text"));
 }
 
 - (void)testParseTemplateError_sections_shouldReadAllTemplateSections {
@@ -81,8 +81,8 @@
 	// verify
 	assertThatBool(result, equalToBool(YES));
 	assertThatInteger([loader.templateSections count], equalToInteger(2));
-	assertThat([loader.templateSections objectForKey:@"name1"], is(@"text1"));
-	assertThat([loader.templateSections objectForKey:@"name2"], is(@"text2"));
+	assertThat(loader.templateSections[@"name1"], is(@"text1"));
+	assertThat(loader.templateSections[@"name2"], is(@"text2"));
 }
 
 - (void)testParseTemplate_sections_shouldReadComplexTemplateSectionValue {
@@ -94,7 +94,7 @@
 	// verify
 	assertThatBool(result, equalToBool(YES));
 	assertThatInteger([loader.templateSections count], equalToInteger(1));
-	assertThat([loader.templateSections objectForKey:@"name"], is(@"first line\nsecond line"));
+	assertThat(loader.templateSections[@"name"], is(@"first line\nsecond line"));
 }
 
 - (void)testParseTemplate_sections_shouldClearBeforeReading {
@@ -106,8 +106,8 @@
 	// verify
 	assertThatBool(result, equalToBool(YES));
 	assertThatInteger([loader.templateSections count], equalToInteger(1));
-	assertThat([loader.templateSections objectForKey:@"name1"], is(nil));
-	assertThat([loader.templateSections objectForKey:@"name2"], isNot(nil));
+	assertThat(loader.templateSections[@"name1"], is(nil));
+	assertThat(loader.templateSections[@"name2"], isNot(nil));
 }
 
 #pragma mark Template string
@@ -174,8 +174,8 @@
 	assertThatBool(result, equalToBool(YES));
 	assertThat(loader.templateString, is(@"Some text\nin multiple lines\nFollowed\nby middle\ntext\nAnd by some\n\tprefix"));
 	assertThatInteger([loader.templateSections count], equalToInteger(2));
-	assertThat([loader.templateSections objectForKey:@"name1"], is(@"text\nline2"));
-	assertThat([loader.templateSections objectForKey:@"name2"], is(@"text2\n\tline2"));
+	assertThat(loader.templateSections[@"name1"], is(@"text\nline2"));
+	assertThat(loader.templateSections[@"name2"], is(@"text2\n\tline2"));
 }
 
 #pragma mark Template handling
@@ -216,7 +216,7 @@
 	GBTemplateHandler *loader = [GBTemplateHandler handler];
 	[loader parseTemplate:@"prefix {{var1}}---{{var2}} suffix" error:nil];
 	// execute
-	NSString *result = [loader renderObject:[NSDictionary dictionaryWithObjectsAndKeys:@"value1", @"var1", @"value2", @"var2", nil]];
+	NSString *result = [loader renderObject:@{@"var1" : @"value1", @"var2" : @"value2"}];
 	// verify
 	assertThat(result, is(@"prefix value1---value2 suffix"));
 }
@@ -245,10 +245,10 @@
 	// setup
 	GBTemplateHandler *loader = [GBTemplateHandler handler];
 	[loader parseTemplate:@"prefix {{#var1}}{{>name}}{{/var1}}! {{#var2}}{{>name}}{{/var2}}? Section name {{value}} EndSection" error:nil];
-	NSDictionary *var1 = [NSDictionary dictionaryWithObjectsAndKeys:@"value1", @"value", nil];
-	NSDictionary *var2 = [NSDictionary dictionaryWithObjectsAndKeys:@"value2", @"value", nil];
+	NSDictionary *var1 = @{@"value" : @"value1"};
+	NSDictionary *var2 = @{@"value" : @"value2"};
 	// execute
-	NSString *result = [loader renderObject:[NSDictionary dictionaryWithObjectsAndKeys:var1, @"var1", var2, @"var2", nil]];
+	NSString *result = [loader renderObject:@{@"var1" : var1, @"var2" : var2}];
 	// verify
 	assertThat(result, is(@"prefix value1! value2?"));
 }

--- a/Testing/GBTemplateVariablesProvider-CommonTesting.m
+++ b/Testing/GBTemplateVariablesProvider-CommonTesting.m
@@ -25,10 +25,10 @@
 	// execute
 	NSDictionary *vars = [provider variablesForClass:class withStore:[GBTestObjectsRegistry store]];
 	// verify - just basic tests...
-	assertThat([vars objectForKey:@"page"], isNot(nil));
+	assertThat(vars[@"page"], isNot(nil));
 	assertThat([vars valueForKeyPath:@"page.title"], isNot(nil));
 	assertThat([vars valueForKeyPath:@"page.specifications"], isNot(nil));
-	assertThat([vars objectForKey:@"object"], is(class));
+	assertThat(vars[@"object"], is(class));
 }
 
 - (void)testVariableForClass_shouldPrepareFooterVariables {

--- a/Testing/GBTemplateVariablesProvider-ObjectSpecificationsTesting.m
+++ b/Testing/GBTemplateVariablesProvider-ObjectSpecificationsTesting.m
@@ -37,11 +37,11 @@
 	NSDictionary *vars = [provider variablesForClass:class withStore:[GBTestObjectsRegistry store]];
 	NSArray *specifications = [vars valueForKeyPath:@"page.specifications.values"];
 	// verify
-	NSDictionary *specification = [specifications objectAtIndex:0];
-	NSArray *values = [specification objectForKey:@"values"];
+	NSDictionary *specification = specifications[0];
+	NSArray *values = specification[@"values"];
 	assertThatInteger([values count], equalToInteger(1));
-	assertThat([[values objectAtIndex:0] objectForKey:@"string"], is(@"NSObject"));
-	assertThat([[values objectAtIndex:0] objectForKey:@"href"], is(nil));
+	assertThat([values[0] objectForKey:@"string"], is(@"NSObject"));
+	assertThat([values[0] objectForKey:@"href"], is(nil));
 }
 
 - (void)testVariablesForClass_inheritsFrom_shouldPrepareSpecificationForKnownSuperclass {
@@ -57,11 +57,11 @@
 	NSDictionary *vars = [provider variablesForClass:class withStore:store];
 	NSArray *specifications = [vars valueForKeyPath:@"page.specifications.values"];
 	// verify
-	NSDictionary *specification = [specifications objectAtIndex:0];
-	NSArray *values = [specification objectForKey:@"values"];
+	NSDictionary *specification = specifications[0];
+	NSArray *values = specification[@"values"];
 	assertThatInteger([values count], equalToInteger(1));
-	assertThat([[values objectAtIndex:0] objectForKey:@"string"], is(@"Base"));
-	assertThat([[values objectAtIndex:0] objectForKey:@"href"], isNot(nil));
+	assertThat([values[0] objectForKey:@"string"], is(@"Base"));
+	assertThat([values[0] objectForKey:@"href"], isNot(nil));
 }
 
 - (void)testVariablesForClass_inheritsFrom_shouldPrepareSpecificationForClassHierarchy {
@@ -82,15 +82,15 @@
 	NSDictionary *vars = [provider variablesForClass:class withStore:store];
 	NSArray *specifications = [vars valueForKeyPath:@"page.specifications.values"];
 	// verify - note that href is created even if superclass is not registered to store as long as a superclass property is non-nil.
-	NSDictionary *specification = [specifications objectAtIndex:0];
-	NSArray *values = [specification objectForKey:@"values"];
+	NSDictionary *specification = specifications[0];
+	NSArray *values = specification[@"values"];
 	assertThatInteger([values count], equalToInteger(3));
-	assertThat([[values objectAtIndex:0] objectForKey:@"string"], is(@"Level1"));
-	assertThat([[values objectAtIndex:0] objectForKey:@"href"], isNot(nil));
-	assertThat([[values objectAtIndex:1] objectForKey:@"string"], is(@"Level2"));
-	assertThat([[values objectAtIndex:1] objectForKey:@"href"], isNot(nil));
-	assertThat([[values objectAtIndex:2] objectForKey:@"string"], is(@"NSObject"));
-	assertThat([[values objectAtIndex:2] objectForKey:@"href"], is(nil));
+	assertThat([values[0] objectForKey:@"string"], is(@"Level1"));
+	assertThat([values[0] objectForKey:@"href"], isNot(nil));
+	assertThat([values[1] objectForKey:@"string"], is(@"Level2"));
+	assertThat([values[1] objectForKey:@"href"], isNot(nil));
+	assertThat([values[2] objectForKey:@"string"], is(@"NSObject"));
+	assertThat([values[2] objectForKey:@"href"], is(nil));
 }
 
 #pragma mark Conforms to
@@ -115,11 +115,11 @@
 	NSDictionary *vars = [provider variablesForClass:class withStore:[GBTestObjectsRegistry store]];
 	NSArray *specifications = [vars valueForKeyPath:@"page.specifications.values"];
 	// verify
-	NSDictionary *specification = [specifications objectAtIndex:0];
-	NSArray *values = [specification objectForKey:@"values"];
+	NSDictionary *specification = specifications[0];
+	NSArray *values = specification[@"values"];
 	assertThatInteger([values count], equalToInteger(1));
-	assertThat([[values objectAtIndex:0] objectForKey:@"string"], is(@"Protocol"));
-	assertThat([[values objectAtIndex:0] objectForKey:@"href"], is(nil));
+	assertThat([values[0] objectForKey:@"string"], is(@"Protocol"));
+	assertThat([values[0] objectForKey:@"href"], is(nil));
 }
 
 - (void)testVariablesForClass_conformsTo_shouldPrepareSpecificationForKnownProtocol {
@@ -134,11 +134,11 @@
 	NSDictionary *vars = [provider variablesForClass:class withStore:store];
 	NSArray *specifications = [vars valueForKeyPath:@"page.specifications.values"];
 	// verify
-	NSDictionary *specification = [specifications objectAtIndex:0];
-	NSArray *values = [specification objectForKey:@"values"];
+	NSDictionary *specification = specifications[0];
+	NSArray *values = specification[@"values"];
 	assertThatInteger([values count], equalToInteger(1));
-	assertThat([[values objectAtIndex:0] objectForKey:@"string"], is(@"Protocol"));
-	assertThat([[values objectAtIndex:0] objectForKey:@"href"], isNot(nil));
+	assertThat([values[0] objectForKey:@"string"], is(@"Protocol"));
+	assertThat([values[0] objectForKey:@"href"], isNot(nil));
 }
 
 - (void)testVariablesForClass_conformsTo_shouldPrepareSpecificationForComplexProtocolsList {
@@ -158,15 +158,15 @@
 	NSDictionary *vars = [provider variablesForClass:class withStore:store];
 	NSArray *specifications = [vars valueForKeyPath:@"page.specifications.values"];
 	// verify
-	NSDictionary *specification = [specifications objectAtIndex:0];
-	NSArray *values = [specification objectForKey:@"values"];
+	NSDictionary *specification = specifications[0];
+	NSArray *values = specification[@"values"];
 	assertThatInteger([values count], equalToInteger(3));
-	assertThat([[values objectAtIndex:0] objectForKey:@"string"], is(@"Protocol1"));
-	assertThat([[values objectAtIndex:0] objectForKey:@"href"], isNot(nil));
-	assertThat([[values objectAtIndex:1] objectForKey:@"string"], is(@"Protocol2"));
-	assertThat([[values objectAtIndex:1] objectForKey:@"href"], is(nil));
-	assertThat([[values objectAtIndex:2] objectForKey:@"string"], is(@"Protocol3"));
-	assertThat([[values objectAtIndex:2] objectForKey:@"href"], isNot(nil));
+	assertThat([values[0] objectForKey:@"string"], is(@"Protocol1"));
+	assertThat([values[0] objectForKey:@"href"], isNot(nil));
+	assertThat([values[1] objectForKey:@"string"], is(@"Protocol2"));
+	assertThat([values[1] objectForKey:@"href"], is(nil));
+	assertThat([values[2] objectForKey:@"string"], is(@"Protocol3"));
+	assertThat([values[2] objectForKey:@"href"], isNot(nil));
 }
 
 #pragma mark Declared in
@@ -180,11 +180,11 @@
 	NSDictionary *vars = [provider variablesForClass:class withStore:[GBTestObjectsRegistry store]];
 	NSArray *specifications = [vars valueForKeyPath:@"page.specifications.values"];
 	// verify
-	NSDictionary *specification = [specifications objectAtIndex:0];
-	NSArray *values = [specification objectForKey:@"values"];
+	NSDictionary *specification = specifications[0];
+	NSArray *values = specification[@"values"];
 	assertThatInteger([values count], equalToInteger(1));
-	assertThat([[values objectAtIndex:0] objectForKey:@"string"], is(@"file.h"));
-	assertThat([[values objectAtIndex:0] objectForKey:@"href"], is(nil));
+	assertThat([values[0] objectForKey:@"string"], is(@"file.h"));
+	assertThat([values[0] objectForKey:@"href"], is(nil));
 }
 
 - (void)testVariablesForClass_declaredIn_shouldPrepareSpecificationForMultipleSourceInfos {
@@ -197,13 +197,13 @@
 	NSDictionary *vars = [provider variablesForClass:class withStore:[GBTestObjectsRegistry store]];
 	NSArray *specifications = [vars valueForKeyPath:@"page.specifications.values"];
 	// verify
-	NSDictionary *specification = [specifications objectAtIndex:0];
-	NSArray *values = [specification objectForKey:@"values"];
+	NSDictionary *specification = specifications[0];
+	NSArray *values = specification[@"values"];
 	assertThatInteger([values count], equalToInteger(2));
-	assertThat([[values objectAtIndex:0] objectForKey:@"string"], is(@"file1.h"));
-	assertThat([[values objectAtIndex:0] objectForKey:@"href"], is(nil));
-	assertThat([[values objectAtIndex:1] objectForKey:@"string"], is(@"file2.h"));
-	assertThat([[values objectAtIndex:1] objectForKey:@"href"], is(nil));
+	assertThat([values[0] objectForKey:@"string"], is(@"file1.h"));
+	assertThat([values[0] objectForKey:@"href"], is(nil));
+	assertThat([values[1] objectForKey:@"string"], is(@"file2.h"));
+	assertThat([values[1] objectForKey:@"href"], is(nil));
 }
 
 @end

--- a/Testing/GBTestObjectsRegistry.m
+++ b/Testing/GBTestObjectsRegistry.m
@@ -33,8 +33,8 @@
 }
 
 + (void)settingsProvider:(OCMockObject *)provider keepObjects:(BOOL)objects keepMembers:(BOOL)members {
-	[[[provider stub] andReturnValue:[NSNumber numberWithBool:objects]] keepUndocumentedObjects];
-	[[[provider stub] andReturnValue:[NSNumber numberWithBool:members]] keepUndocumentedMembers];
+	[[[provider stub] andReturnValue:@(objects)] keepUndocumentedObjects];
+	[[[provider stub] andReturnValue:@(members)] keepUndocumentedMembers];
 }
 
 + (void)registerComment:(id)comment forObject:(GBModelBase *)object {
@@ -70,7 +70,7 @@
 		[arguments addObject:argument];
 	}
 	va_end(args);
-	return [GBMethodData methodDataWithType:GBMethodTypeInstance result:[NSArray arrayWithObject:@"void"] arguments:arguments];
+	return [GBMethodData methodDataWithType:GBMethodTypeInstance result:@[@"void"] arguments:arguments];
 }
 
 + (GBMethodData *)classMethodWithArguments:(GBMethodArgument *)first,... {
@@ -81,7 +81,7 @@
 		[arguments addObject:argument];
 	}
 	va_end(args);
-	return [GBMethodData methodDataWithType:GBMethodTypeClass result:[NSArray arrayWithObject:@"void"] arguments:arguments];
+	return [GBMethodData methodDataWithType:GBMethodTypeClass result:@[@"void"] arguments:arguments];
 }
 
 + (GBMethodData *)instanceMethodWithNames:(NSString *)first,... {
@@ -93,7 +93,7 @@
 		[arguments addObject:argument];
 	}
 	va_end(args);
-	return [GBMethodData methodDataWithType:GBMethodTypeInstance result:[NSArray arrayWithObject:@"void"] arguments:arguments];
+	return [GBMethodData methodDataWithType:GBMethodTypeInstance result:@[@"void"] arguments:arguments];
 }
 
 + (GBMethodData *)classMethodWithNames:(NSString *)first,... {
@@ -105,16 +105,16 @@
 		[arguments addObject:argument];
 	}
 	va_end(args);
-	return [GBMethodData methodDataWithType:GBMethodTypeClass result:[NSArray arrayWithObject:@"void"] arguments:arguments];
+	return [GBMethodData methodDataWithType:GBMethodTypeClass result:@[@"void"] arguments:arguments];
 }
 
 + (GBMethodData *)propertyMethodWithArgument:(NSString *)name {
 	GBMethodArgument *argument = [GBMethodArgument methodArgumentWithName:name];
-	return [GBMethodData methodDataWithType:GBMethodTypeProperty result:[NSArray arrayWithObject:@"int"] arguments:[NSArray arrayWithObject:argument]];
+	return [GBMethodData methodDataWithType:GBMethodTypeProperty result:@[@"int"] arguments:@[argument]];
 }
 
 + (GBMethodArgument *)typedArgumentWithName:(NSString *)name {
-	return [GBMethodArgument methodArgumentWithName:name types:[NSArray arrayWithObject:@"id"] var:name];
+	return [GBMethodArgument methodArgumentWithName:name types:@[@"id"] var:name];
 }
 
 #pragma mark Store objects creation methods

--- a/Testing/GBTokenizerTesting.m
+++ b/Testing/GBTokenizerTesting.m
@@ -197,10 +197,10 @@
 	}];
 	// verify
 	assertThatInteger([tokens count], equalToInteger(4));
-	assertThat([tokens objectAtIndex:0], is(@"one"));
-	assertThat([tokens objectAtIndex:1], is(@"two"));
-	assertThat([tokens objectAtIndex:2], is(@"three"));
-	assertThat([tokens objectAtIndex:3], is(@"four"));
+	assertThat(tokens[0], is(@"one"));
+	assertThat(tokens[1], is(@"two"));
+	assertThat(tokens[2], is(@"three"));
+	assertThat(tokens[3], is(@"four"));
 }
 
 - (void)testConsumeFromToUsingBlock_shouldReportAllTokensFromTo {
@@ -213,9 +213,9 @@
 	}];
 	// verify
 	assertThatInteger([tokens count], equalToInteger(3));
-	assertThat([tokens objectAtIndex:0], is(@"two"));
-	assertThat([tokens objectAtIndex:1], is(@"three"));
-	assertThat([tokens objectAtIndex:2], is(@"four"));
+	assertThat(tokens[0], is(@"two"));
+	assertThat(tokens[1], is(@"three"));
+	assertThat(tokens[2], is(@"four"));
 }
 
 - (void)testConsumeFromToUsingBlock_shouldReturnIfStartTokenDoesntMatch {

--- a/Testing/GObjectiveCParser-BlockParsingTesting.m
+++ b/Testing/GObjectiveCParser-BlockParsingTesting.m
@@ -54,7 +54,7 @@
     GBTypedefBlockArgument *blockArgument = [[blockData parameters] firstObject];
     assertThat(blockArgument.className, equalTo(@"BOOL"));
     assertThat(blockArgument.name, equalTo(@"boolean"));
-    blockArgument = [[blockData parameters] objectAtIndex:1];
+    blockArgument = [blockData parameters][1];
     assertThat(blockArgument.className, equalTo(@"NSString"));
     assertThat(blockArgument.name, equalTo(@"*string"));
 }
@@ -76,7 +76,7 @@
     GBTypedefBlockArgument *blockArgument = [[blockData parameters] firstObject];
     assertThat(blockArgument.className, equalTo(@"BOOL"));
     assertThat(blockArgument.name, equalTo(@""));
-    blockArgument = [[blockData parameters] objectAtIndex:1];
+    blockArgument = [blockData parameters][1];
     assertThat(blockArgument.className, equalTo(@"NSString"));
     assertThat(blockArgument.name, equalTo(@"*"));
 }


### PR DESCRIPTION
Went through the project and updated statements that can use modern syntax. Along the way a few if and return statements were simplified. Additionally, after noticing issue #563 I added a fix for the NSCalendar issue requiring compiling against OS X 10.9.