### PR TITLE
Localized the GBApplicationStringsProvider class to support documentation localization.

### DIFF
--- a/Application/GBApplicationStringsProvider.m
+++ b/Application/GBApplicationStringsProvider.m
@@ -22,14 +22,14 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		result[@"classTitle"] = @"%@ Class Reference";
-		result[@"categoryTitle"] = @"%1$@(%2$@) Category Reference";
-		result[@"protocolTitle"] = @"%@ Protocol Reference";
-		result[@"constantTitle"] = @"%@ Constants Reference";
-        result[@"blockTitle"] = @"%@ Block Reference";
-		result[@"mergedCategorySectionTitle"] = @"%@ Methods";
-		result[@"mergedExtensionSectionTitle"] = @"Extension Methods";
-		result[@"mergedPrefixedCategorySectionTitle"] = @"%2$@ from %1$@";
+		result[@"classTitle"] = NSLocalizedString(@"%@ Class Reference", @"%@ Class Reference");
+		result[@"categoryTitle"] = NSLocalizedString(@"%1$@(%2$@) Category Reference", @"%1$@(%2$@) Category Reference");
+		result[@"protocolTitle"] = NSLocalizedString(@"%@ Protocol Reference", @"%@ Protocol Reference");
+		result[@"constantTitle"] = NSLocalizedString(@"%@ Constants Reference", @"%@ Constants Reference");
+        result[@"blockTitle"] = NSLocalizedString(@"%@ Block Reference", @"%@ Block Reference");
+		result[@"mergedCategorySectionTitle"] = NSLocalizedString(@"%@ Methods", @"%@ Methods");
+		result[@"mergedExtensionSectionTitle"] = NSLocalizedString(@"Extension Methods", @"Extension Methods");
+		result[@"mergedPrefixedCategorySectionTitle"] = NSLocalizedString(@"%2$@ from %1$@", @"%2$@ from %1$@");
 	}
 	return result;
 }
@@ -38,12 +38,12 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		result[@"inheritsFrom"] = @"Inherits from";
-		result[@"conformsTo"] = @"Conforms to";
-        result[@"references"] = @"References";
-        result[@"availability"] = @"Availability";
-		result[@"declaredIn"] = @"Declared in";
-		result[@"companionGuide"] = @"Companion guide";
+		result[@"inheritsFrom"] = NSLocalizedString(@"Inherits from", @"Inherits from");
+		result[@"conformsTo"] = NSLocalizedString(@"Conforms to", @"Conforms to");
+        result[@"references"] = NSLocalizedString(@"References", @"References");
+        result[@"availability"] = NSLocalizedString(@"Availability", @"Availability");
+		result[@"declaredIn"] = NSLocalizedString(@"Declared in", @"Declared in");
+		result[@"companionGuide"] = NSLocalizedString(@"Companion guide", @"Companion guide");
 	}
 	return result;
 }
@@ -52,7 +52,7 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		result[@"title"] = @"Overview";
+		result[@"title"] = NSLocalizedString(@"Overview", @"Overview");
 	}
 	return result;
 }
@@ -61,10 +61,10 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		result[@"title"] = @"Tasks";
-		result[@"otherMethodsSectionName"] = @"Other Methods";
-		result[@"requiredMethod"] = @"required method";
-		result[@"property"] = @"property";
+		result[@"title"] = NSLocalizedString(@"Tasks", @"Tasks");
+		result[@"otherMethodsSectionName"] = NSLocalizedString(@"Other Methods", @"Other Methods");
+		result[@"requiredMethod"] = NSLocalizedString(@"required method", @"required method");
+		result[@"property"] = NSLocalizedString(@"property", @"property");
 	}
 	return result;
 }
@@ -73,17 +73,17 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		result[@"classMethodsTitle"] = @"Class Methods";
-		result[@"instanceMethodsTitle"] = @"Instance Methods";
-        result[@"blockDefTitle"] = @"Block Definition";
-		result[@"propertiesTitle"] = @"Properties";
-		result[@"parametersTitle"] = @"Parameters";
-		result[@"resultTitle"] = @"Return Value";
-		result[@"availability"] = @"Availability";
-		result[@"discussionTitle"] = @"Discussion";
-		result[@"exceptionsTitle"] = @"Exceptions";
-		result[@"seeAlsoTitle"] = @"See Also";
-		result[@"declaredInTitle"] = @"Declared In";
+		result[@"classMethodsTitle"] = NSLocalizedString(@"Class Methods", @"Class Methods");
+		result[@"instanceMethodsTitle"] = NSLocalizedString(@"Instance Methods", @"Instance Methods");
+        result[@"blockDefTitle"] = NSLocalizedString(@"Block Definition", @"Block Definition");
+		result[@"propertiesTitle"] = NSLocalizedString(@"Properties", @"Properties");
+		result[@"parametersTitle"] = NSLocalizedString(@"Parameters", @"Parameters");
+		result[@"resultTitle"] = NSLocalizedString(@"Return Value", @"Return Value");
+		result[@"availability"] = NSLocalizedString(@"Availability", @"Availability");
+		result[@"discussionTitle"] = NSLocalizedString(@"Discussion", @"Discussion");
+		result[@"exceptionsTitle"] = NSLocalizedString(@"Exceptions", @"Exceptions");
+		result[@"seeAlsoTitle"] = NSLocalizedString(@"See Also", @"See Also");
+		result[@"declaredInTitle"] = NSLocalizedString(@"Declared In", @"Declared In");
 	}
 	return result;
 }
@@ -94,7 +94,7 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		result[@"titleTemplate"] = @"%@ Document";
+		result[@"titleTemplate"] = NSLocalizedString(@"%@ Document", @"%@ Document");
 	}
 	return result;
 }
@@ -105,13 +105,13 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		result[@"titleTemplate"] = @"%@ Reference";
-		result[@"docsTitle"] = @"Programming Guides";
-		result[@"classesTitle"] = @"Class References";
-		result[@"categoriesTitle"] = @"Category References";
-		result[@"protocolsTitle"] = @"Protocol References";
-        result[@"constantsTitle"] = @"Constant References";
-        result[@"blocksTitle"] = @"Block References";
+		result[@"titleTemplate"] = NSLocalizedString(@"%@ Reference", @"%@ Reference");
+		result[@"docsTitle"] = NSLocalizedString(@"Programming Guides", @"Programming Guides");
+		result[@"classesTitle"] = NSLocalizedString(@"Class References", @"Class References");
+		result[@"categoriesTitle"] = NSLocalizedString(@"Category References", @"Category References");
+		result[@"protocolsTitle"] = NSLocalizedString(@"Protocol References", @"Protocol References");
+        result[@"constantsTitle"] = NSLocalizedString(@"Constant References", @"Constant References");
+        result[@"blocksTitle"] = NSLocalizedString(@"Block References", @"Block References");
 	}
 	return result;
 }
@@ -120,12 +120,12 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		result[@"titleTemplate"] = @"%@ Hierarchy";
-		result[@"classesTitle"] = @"Class Hierarchy";
-		result[@"categoriesTitle"] = @"Category References";
-		result[@"protocolsTitle"] = @"Protocol References";
-        result[@"constantsTitle"] = @"Constant References";
-        result[@"blocksTitle"] = @"Block References";
+		result[@"titleTemplate"] = NSLocalizedString(@"%@ Hierarchy", @"%@ Hierarchy");
+		result[@"classesTitle"] = NSLocalizedString(@"Class Hierarchy", @"Class Hierarchy");
+		result[@"categoriesTitle"] = NSLocalizedString(@"Category References", @"Category References");
+		result[@"protocolsTitle"] = NSLocalizedString(@"Protocol References", @"Protocol References");
+        result[@"constantsTitle"] = NSLocalizedString(@"Constant References", @"Constant References");
+        result[@"blocksTitle"] = NSLocalizedString(@"Block References", @"Block References");
 	}
 	return result;
 }
@@ -136,12 +136,12 @@
 	static NSMutableDictionary *result = nil;
 	if (!result) {
 		result = [[NSMutableDictionary alloc] init];
-		result[@"docsTitle"] = @"Programming Guides";
-		result[@"classesTitle"] = @"Classes";
-		result[@"categoriesTitle"] = @"Categories";
-		result[@"protocolsTitle"] = @"Protocols";
-        result[@"constantsTitle"] = @"Constants";
-        result[@"blocksTitle"] = @"Blocks";
+		result[@"docsTitle"] = NSLocalizedString(@"Programming Guides", @"Programming Guides");
+		result[@"classesTitle"] = NSLocalizedString(@"Classes", @"Classes");
+		result[@"categoriesTitle"] = NSLocalizedString(@"Categories", @"Categories");
+		result[@"protocolsTitle"] = NSLocalizedString(@"Protocols", @"Protocols");
+        result[@"constantsTitle"] = NSLocalizedString(@"Constants", @"Constants");
+        result[@"blocksTitle"] = NSLocalizedString(@"Blocks", @"Blocks");
 	}
 	return result;
 }

--- a/Application/Localizable.strings
+++ b/Application/Localizable.strings
@@ -1,0 +1,48 @@
+/****************************************************************************/
+/* Localization file */
+
+
+"%@ Class Reference" = "%@ Class Reference";
+"%1$@(%2$@) Category Reference" = "%1$@(%2$@) Category Reference";
+"%@ Protocol Reference" = "%@ Protocol Reference";
+"%@ Constants Reference" = "%@ Constants Reference";
+"%@ Block Reference" = "%@ Block Reference";
+"%@ Methods" = "%@ Methods";
+"Extension Methods" = "Extension Methods";
+"%2$@ from %1$@" = "%2$@ from %1$@";
+"Inherits from" = "Inherits from";
+"Conforms to" = "Conforms to";
+"References" = "References";
+"Availability" = "Availability";
+"Declared in" = "Declared in";
+"Companion guide" = "Companion guide";
+"Overview" = "Overview";
+"Tasks" = "Tasks";
+"Other Methods" = "Other Methods";
+"required method" = "required method";
+"property" = "property";
+"Class Methods" = "Class Methods";
+"Instance Methods" = "Instance Methods";
+"Block Definition" = "Block Definition";
+"Properties" = "Properties";
+"Parameters" = "Parameters";
+"Return Value" = "Return Value";
+"Discussion" = "Discussion";
+"Exceptions" = "Exceptions";
+"See Also" = "See Also";
+"Declared In" = "Declared In";
+"%@ Document" = "%@ Document";
+"%@ Reference" = "%@ Reference";
+"Programming Guides" = "Programming Guides";
+"Class References" = "Class References";
+"Category References" = "Category References";
+"Protocol References" = "Protocol References";
+"Constant References" = "Constant References";
+"Block References" = "Block References";
+"%@ Hierarchy" = "%@ Hierarchy";
+"Class Hierarchy" = "Class Hierarchy";
+"Classes" = "Classes";
+"Categories" = "Categories";
+"Protocols" = "Protocols";
+"Constants" = "Constants";
+"Blocks" = "Blocks";

--- a/appledoc.xcodeproj/project.pbxproj
+++ b/appledoc.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		7D11DEC717BA62420027DC2D /* GBEnumConstantProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B844F117A122A50012C1DC /* GBEnumConstantProvider.m */; };
 		86466CB01AAA1477002B003C /* GObjectiveCParser-BlockParsingTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = 86466CAF1AAA1477002B003C /* GObjectiveCParser-BlockParsingTesting.m */; };
 		8DD76F9C0486AA7600D96B5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08FB779EFE84155DC02AAC07 /* Foundation.framework */; };
+		9328C127BD1269A1A2447359 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9328CE2BEBC125BF215A96C1 /* Localizable.strings */; };
 		B4D1FFD515FF5F05009736E2 /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = B4D1FFC115FF5F05009736E2 /* ioapi.c */; };
 		B4D1FFD615FF5F05009736E2 /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = B4D1FFC115FF5F05009736E2 /* ioapi.c */; };
 		B4D1FFD715FF5F05009736E2 /* mztools.c in Sources */ = {isa = PBXBuildFile; fileRef = B4D1FFC315FF5F05009736E2 /* mztools.c */; };
@@ -469,6 +470,7 @@
 		75C6C0D416CAA8D900E254F7 /* XcodeIntegrationScript.markdown */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = XcodeIntegrationScript.markdown; sourceTree = "<group>"; };
 		86466CAF1AAA1477002B003C /* GObjectiveCParser-BlockParsingTesting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "GObjectiveCParser-BlockParsingTesting.m"; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* appledoc */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = appledoc; sourceTree = BUILT_PRODUCTS_DIR; };
+		9328CE2BEBC125BF215A96C1 /* Localizable.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = Application/Localizable.strings; sourceTree = "<group>"; };
 		B4D1FFC015FF5F05009736E2 /* crypt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypt.h; sourceTree = "<group>"; };
 		B4D1FFC115FF5F05009736E2 /* ioapi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ioapi.c; sourceTree = "<group>"; };
 		B4D1FFC215FF5F05009736E2 /* ioapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ioapi.h; sourceTree = "<group>"; };
@@ -579,6 +581,7 @@
 				7340F0AB11FCC87300E712A4 /* Testing */,
 				08FB779DFE84155DC02AAC07 /* Libraries & Frameworks */,
 				1AB674ADFE9D54B511CA2CBB /* Products */,
+				9328CE2BEBC125BF215A96C1 /* Localizable.strings */,
 			);
 			name = appledoc;
 			sourceTree = "<group>";
@@ -1218,6 +1221,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9328C127BD1269A1A2447359 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Localizing the GBApplicationStringsProvider class is the first step for allowing appledoc to output localized API documentation.This also partially addresses issues such as #560, where one would want to easily customize the template text. Keep in mind this is a first step toward proper localization of appledoc to support outputting documentation for other locales and the process will get further refined to become as simple as possible.

For everyone that reads this pull request, the process for localization with this first step involves the following steps:

 1. Translate the Localizable.strings file. This file uses a "key" = "value" format, you'd translate the "value" portion. Optionally, if your build machine OS X uses your target language as the displayed language, you can add your localization folder to the project with files for translation copied there. To read more about localizing with Xcode, [read this topic] (https://developer.apple.com/library/ios/documentation/MacOSX/Conceptual/BPInternational/LocalizingYourApp/LocalizingYourApp.html).
 2. Translate the hard coded strings in the HTML documents in the Templates/html path or copy the Templates folder to another location and translate. Be sure to avoid translating template text. If you plan on using a copy of the Templates folder, you can specify it's path to the appledoc command line with the --templates "/path/to/template" option when building documentation.