### PR TITLE
fix targeting for href deeplinks

### DIFF
--- a/Templates/html/object-template.html
+++ b/Templates/html/object-template.html
@@ -100,7 +100,7 @@
                         <h4 class="method-subtitle">Definition</h4>
                         <code>typedef {{enumStyle}}({{enumPrimitive}}, {{nameOfEnum}} ) {<br>
                             {{#constants}}
-                            &nbsp;&nbsp; <a href="{{htmlLocalReference}}">{{name}}</a>{{#hasAssignedValue}} = {{assignedValue}}{{/hasAssignedValue}},<br>
+                            &nbsp;&nbsp; <a href="#{{name}}">{{name}}</a>{{#hasAssignedValue}} = {{assignedValue}}{{/hasAssignedValue}},<br>
                             {{/constants}}
                             };</code>
                     {{/constants}}


### PR DESCRIPTION
previously, the method of injection would leave the field empty (thus breaking the feature and making my tests angry). this is a hacky way of getting it to properly inject the method name.