### PR TITLE
Fix tests loader helper

### DIFF
--- a/tests/Helpers/Loader.swift
+++ b/tests/Helpers/Loader.swift
@@ -35,7 +35,7 @@ class Loader {
 		let value = contents.substringWithRange(exampleRange)
 		
 		// Prepare temporary path and save the example there.
-		let tempPath = NSTemporaryDirectory().stringByAppendingPathComponent("\(NSUUID())")
+		let tempPath = NSTemporaryDirectory().stringByAppendingPathComponent("\(NSUUID().UUIDString).m")
 		try! value.writeToFile(tempPath, atomically: true, encoding: NSUTF8StringEncoding)
 		
 		return PathInfo(path: tempPath)

--- a/tests/Parser/ObjectiveCParser-ClassExtensionsSpec.swift
+++ b/tests/Parser/ObjectiveCParser-ClassExtensionsSpec.swift
@@ -6,7 +6,7 @@
 import Quick
 import Nimble
 
-class ObjectiveCParserClassSpec: QuickSpec {
+class ObjectiveCParserClassExtensionSpec: QuickSpec {
 	
 	override func spec() {
 		

--- a/tests/Parser/ObjectiveCParser-ClassSpec.swift
+++ b/tests/Parser/ObjectiveCParser-ClassSpec.swift
@@ -6,7 +6,7 @@
 import Quick
 import Nimble
 
-class ObjectiveCParserClassExtensionSpec: QuickSpec {
+class ObjectiveCParserClassSpec: QuickSpec {
 	
 	override func spec() {
 		


### PR DESCRIPTION
- Use the UUID value as the filename (not the object's description) and clang doesn't parse the file without the .m extension (didn't try other extensions).
- Correctly name class and class extension specs