### PR TITLE
Update install-appledoc.sh

### DIFF
--- a/install-appledoc.sh
+++ b/install-appledoc.sh
@@ -42,7 +42,7 @@ done
 echo "Building..."
 xcodebuild -workspace appledoc.xcworkspace -scheme appledoc -derivedDataPath /tmp -configuration Release install
 
-install -v /tmp/Build/Intermediates/ArchiveIntermediates/appledoc/InstallationBuildProductsLocation/usr/local/bin/appledoc "$BINARY_DIR"
+install -v /tmp/Build/Intermediates.noindex/ArchiveIntermediates/appledoc/InstallationBuildProductsLocation/usr/local/bin/appledoc "$BINARY_DIR"
 
 if [ "$INSTALL_TEMPLATES" == "YES" ]; then
     echo "Copying templates to $TEMPLATES_DIR"


### PR DESCRIPTION
use /tmp/Build/Intermediates.noindex dir 
for Xcode9.0 change the dir name to  Intermediates.noindex.  This improves build times by preventing Spotlight from indexing the folder.
as metion in 
https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html