### PR TITLE
Markdown Generator

### DIFF
--- a/AppledocTests-Info.plist
+++ b/AppledocTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.gentlebytes.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/Application/GBAppledocApplication.m
+++ b/Application/GBAppledocApplication.m
@@ -36,6 +36,7 @@ static char *kGBArgCompanyIdentifier = "company-id";
 
 static char *kGBArgCleanOutput = "clean-output";
 static char *kGBArgCreateHTML = "create-html";
+static char *kGBArgCreateMarkdown = "create-markdown";
 static char *kGBArgCreateDocSet = "create-docset";
 static char *kGBArgFinalizeDocSet = "finalize-docset";
 static char *kGBArgInstallDocSet = "install-docset";
@@ -273,12 +274,15 @@ static char *kGBArgHelp = "help";
 		
 		{ kGBArgCleanOutput,												0,		DDGetoptNoArgument },
 		{ kGBArgCreateHTML,													'h',	DDGetoptNoArgument },
+        { kGBArgCreateMarkdown,                                             'm',    DDGetoptNoArgument },
+
 		{ kGBArgCreateDocSet,												'd',	DDGetoptNoArgument },
 		{ kGBArgFinalizeDocSet,												0,	DDGetoptNoArgument },
 		{ kGBArgInstallDocSet,												'n',	DDGetoptNoArgument },
 		{ kGBArgPublishDocSet,												'u',	DDGetoptNoArgument },
         { kGBArgHTMLAnchorFormat,                                           0,      DDGetoptRequiredArgument },
 		{ GBNoArg(kGBArgCreateHTML),										0,		DDGetoptNoArgument },
+        { GBNoArg(kGBArgCreateMarkdown),                                    0,      DDGetoptNoArgument },
 		{ GBNoArg(kGBArgCreateDocSet),										0,		DDGetoptNoArgument },
 		{ GBNoArg(kGBArgInstallDocSet),										0,		DDGetoptNoArgument },
 		{ GBNoArg(kGBArgPublishDocSet),										0,		DDGetoptNoArgument },
@@ -764,6 +768,9 @@ static char *kGBArgHelp = "help";
 		self.settings.publishDocSet = NO;
 	}
 }
+- (void)setCreateMarkdown:(BOOL)value {
+    self.settings.createMarkdown = value;
+}
 - (void)setCreateDocset:(BOOL)value {
 	self.settings.createDocSet = value;
 	if (value) {
@@ -956,6 +963,7 @@ static char *kGBArgHelp = "help";
     
     ddprintf(@"--%s = %@\n", kGBArgCleanOutput, PRINT_BOOL(self.settings.cleanupOutputPathBeforeRunning));
     ddprintf(@"--%s = %@\n", kGBArgCreateHTML, PRINT_BOOL(self.settings.createHTML));
+    ddprintf(@"--%s = %@\n", kGBArgCreateMarkdown, PRINT_BOOL(self.settings.createMarkdown));
     ddprintf(@"--%s = %@\n", kGBArgCreateDocSet, PRINT_BOOL(self.settings.createDocSet));
     ddprintf(@"--%s = %@\n", kGBArgInstallDocSet, PRINT_BOOL(self.settings.installDocSet));
     ddprintf(@"--%s = %@\n", kGBArgPublishDocSet, PRINT_BOOL(self.settings.publishDocSet));
@@ -1024,6 +1032,7 @@ static char *kGBArgHelp = "help";
 	ddprintf(@"\n");
 	ddprintf(@"OUTPUT GENERATION\n");
 	PRINT_USAGE(@"-h,", kGBArgCreateHTML, @"", @"[b] Create HTML");
+    PRINT_USAGE(@"-m,", kGBArgCreateMarkdown, @"", @"[b] Create markdown");
 	PRINT_USAGE(@"-d,", kGBArgCreateDocSet, @"", @"[b] Create documentation set");
 	PRINT_USAGE(@"-n,", kGBArgInstallDocSet, @"", @"[b] Install documentation set to Xcode");
 	PRINT_USAGE(@"-u,", kGBArgPublishDocSet, @"", @"[b] Prepare DocSet for publishing");

--- a/Application/GBApplicationSettingsProvider.h
+++ b/Application/GBApplicationSettingsProvider.h
@@ -220,6 +220,16 @@ NSString *NSStringFromGBPublishedFeedFormats(GBPublishedFeedFormats format);
  */
 @property (assign) BOOL createHTML;
 
+
+/** Indicates whether markdown files should be generated.
+ 
+ If `YES`, markdown files are generated in `outputPath` from parsed and processed data.
+ 
+ */
+@property (assign) BOOL createMarkdown;
+
+
+
 /** Specifies whether documentation set should be created from the HTML files.
  
  If `YES`, HTML files from html subdirectory in `outputPath` are moved to proper subdirectory within docset output files, then helper files are generated from parsed data. Documentation set files are also indexed. If `NO`, HTML files are left in the output path.

--- a/Application/GBApplicationSettingsProvider.h
+++ b/Application/GBApplicationSettingsProvider.h
@@ -675,6 +675,10 @@ NSString *NSStringFromGBPublishedFeedFormats(GBPublishedFeedFormats format);
 /// @name Helper methods
 ///---------------------------------------------------------------------------------------
 
+
+- (NSString *)outputPathForObject:(id)object withExtension:(NSString *)extension;
+
+
 /** Replaces all occurences of placeholder strings in all related values of the receiver.
  
  This message should be sent once all the values have been set. It is a convenience method that prepares all values that can use placeholder strings. From this point on, the rest of the application can simply use properties to get final values instead of sending `stringByReplacingOccurencesOfPlaceholdersInString:` all the time.

--- a/Application/GBApplicationSettingsProvider.m
+++ b/Application/GBApplicationSettingsProvider.m
@@ -416,6 +416,7 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBApplicationSettingsProvider, sharedApplicationS
 	return memberPath;
 }
 
+
 - (NSString *)htmlReferenceForObjectFromIndex:(GBModelBase *)object {
 	return [self outputPathForObject:object withExtension:[self htmlExtension]];
 }

--- a/Application/GBApplicationSettingsProvider.m
+++ b/Application/GBApplicationSettingsProvider.m
@@ -130,6 +130,7 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBApplicationSettingsProvider, sharedApplicationS
         self.excludeOutputPaths = [NSMutableSet set];
 		
 		self.createHTML = YES;
+        self.createMarkdown = NO;
 		self.createDocSet = YES;
 		self.installDocSet = YES;
 		self.publishDocSet = NO;
@@ -703,6 +704,7 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBApplicationSettingsProvider, sharedApplicationS
 @synthesize embedAppledocBoldMarkersWhenProcessingMarkdown;
 
 @synthesize createHTML;
+@synthesize createMarkdown;
 @synthesize createDocSet;
 @synthesize installDocSet;
 @synthesize publishDocSet;

--- a/Common/GBLog.h
+++ b/Common/GBLog.h
@@ -82,7 +82,7 @@ void GBLogUpdateResult(NSInteger result);
 // in higher level log formats. The information is already verbose enough!
 #define GBLogExceptionLine(frmt,...) { ddprintf(frmt, ##__VA_ARGS__); ddprintf(@"\n"); }
 #define GBLogExceptionNoStack(exception,frmt,...) { \
-	if (frmt) GBLogExceptionLine(frmt, ##__VA_ARGS__); \
+	if (frmt.length > 0) GBLogExceptionLine(frmt, ##__VA_ARGS__); \
 	GBLogExceptionLine(@"%@: %@", [exception name], [exception reason]); \
 }
 #define GBLogException(exception,frmt,...) { \
@@ -93,7 +93,7 @@ void GBLogUpdateResult(NSInteger result);
 	} \
 }
 #define GBLogNSError(error,frmt,...) { \
-	if (frmt) GBLogExceptionLine(frmt, ##__VA_ARGS__); \
+	if (frmt.length > 0) GBLogExceptionLine(frmt, ##__VA_ARGS__); \
 	if ([error localizedDescription]) GBLogExceptionLine(@"%@", [error localizedDescription]); \
 	if ([error localizedFailureReason]) GBLogExceptionLine(@"%@", [error localizedFailureReason]); \
 }

--- a/Common/ThirdParty/DDCli/DDCliApplication.h
+++ b/Common/ThirdParty/DDCli/DDCliApplication.h
@@ -143,7 +143,7 @@ int DDCliAppRunWithClass(Class delegateClass);
  * class is used as the delegate class, so be sure to only include a single
  * class that implements this protocol per application.
  */
-int DDCliAppRunWithDefaultClass();
+int DDCliAppRunWithDefaultClass(void);
 
 /** @} */
 

--- a/Generating/GBGenerator.m
+++ b/Generating/GBGenerator.m
@@ -13,6 +13,7 @@
 #import "GBDocSetFinalizeGenerator.h"
 #import "GBDocSetInstallGenerator.h"
 #import "GBDocSetPublishGenerator.h"
+#import "GBMarkdownOutputGenerator.h"
 #import "GBGenerator.h"
 
 @interface GBGenerator ()
@@ -57,6 +58,9 @@
 - (void)setupGeneratorStepsWithStore:(id)store {
 	// Setups all output generators. The order of these is crucial as they are invoked in the order added to the list. This forms a dependency where each next generator can use
 	GBLogDebug(@"Initializing generation steps...");
+    if (self.settings.createMarkdown) {
+        [self.outputGenerators addObject:[GBMarkdownOutputGenerator generatorWithSettingsProvider:self.settings]];
+    }
 	if (!self.settings.createHTML) return;
 	[self.outputGenerators addObject:[GBHTMLOutputGenerator generatorWithSettingsProvider:self.settings]];
 	if (!self.settings.createDocSet) return;

--- a/Generating/GBMarkdownOutputGenerator.h
+++ b/Generating/GBMarkdownOutputGenerator.h
@@ -1,0 +1,13 @@
+//
+//  GBMarkdownOutputGenerator.h
+//  appledoc
+//
+//  Created by Matthew Murray on 3/1/18.
+//  Copyright © 2018 Gentle Bytes. All rights reserved.
+//
+
+#import "GBOutputGenerator.h"
+
+@interface GBMarkdownOutputGenerator : GBOutputGenerator
+
+@end

--- a/Generating/GBMarkdownOutputGenerator.m
+++ b/Generating/GBMarkdownOutputGenerator.m
@@ -1,0 +1,195 @@
+//
+//  GBMarkdownOutputGenerator.m
+//  appledoc
+//
+//  Created by Matthew Murray on 3/1/18.
+//  Copyright © 2018 Gentle Bytes. All rights reserved.
+//
+
+#import "GBMarkdownOutputGenerator.h"
+#import "GBStore.h"
+#import "GBApplicationSettingsProvider.h"
+#import "GBDataObjects.h"
+#import "GBHTMLTemplateVariablesProvider.h"
+#import "GBTemplateHandler.h"
+
+@interface GBMarkdownOutputGenerator ()
+    
+- (BOOL)validateTemplates:(NSError **)error;
+- (BOOL)processClasses:(NSError **)error;
+- (BOOL)processCategories:(NSError **)error;
+- (BOOL)processProtocols:(NSError **)error;
+- (BOOL)processConstants:(NSError **)error;
+- (BOOL)processBlocks:(NSError **)error;
+- (NSString *)markdownOutputPathForObject:(GBModelBase *)object;
+- (NSString *)stringByCleaningHtml:(NSString *)string;
+//- (NSString *)htmlOutputPathForObject:(GBModelBase *)object;
+//@property (readonly) GBTemplateHandler *htmlObjectTemplate;
+@property (readonly) GBTemplateHandler *markdownTemplate;
+@property (readonly) GBHTMLTemplateVariablesProvider *variablesProvider;
+    
+@end
+
+@implementation GBMarkdownOutputGenerator
+
+#pragma Generation handling
+
+- (BOOL)generateOutputWithStore:(id)store error:(NSError **)error {
+    if (![super generateOutputWithStore:store error:error]) return NO;
+    if (![self validateTemplates:error]) return NO;
+    if (![self processClasses:error]) return NO;
+    if (![self processCategories:error]) return NO;
+    if (![self processProtocols:error]) return NO;
+    if (![self processConstants:error]) return NO;
+    if (![self processBlocks:error]) return NO;
+    return YES;
+}
+
+- (BOOL)processClasses:(NSError **)error {
+    for (GBClassData *class in self.store.classes) {
+        if (!class.includeInOutput) continue;
+        GBLogInfo(@"Generating output for class %@...", class);
+        NSDictionary *vars = [self.variablesProvider variablesForClass:class withStore:self.store];
+        NSString *output = [self.markdownTemplate renderObject:vars];
+//        NSString *output = [self.htmlObjectTemplate renderObject:vars];
+        NSString *cleaned = [self stringByCleaningHtml:output];
+        NSString *path = [self htmlOutputPathForObject:class];
+        if (![self writeString:cleaned toFile:[path stringByStandardizingPath] error:error]) {
+            GBLogWarn(@"Failed writing HTML for class %@ to '%@'!", class, path);
+            return NO;
+        }
+        GBLogDebug(@"Finished generating output for class %@.", class);
+    }
+    return YES;
+}
+
+- (BOOL)processCategories:(NSError **)error {
+    for (GBCategoryData *category in self.store.categories) {
+        if (!category.includeInOutput) continue;
+        GBLogInfo(@"Generating output for category %@...", category);
+        NSDictionary *vars = [self.variablesProvider variablesForCategory:category withStore:self.store];
+        NSString *output = [self.markdownTemplate renderObject:vars];
+//        NSString *output = [self.htmlObjectTemplate renderObject:vars];
+        NSString *cleaned = [self stringByCleaningHtml:output];
+        NSString *path = [self htmlOutputPathForObject:category];
+        if (![self writeString:cleaned toFile:[path stringByStandardizingPath] error:error]) {
+            GBLogWarn(@"Failed writing HTML for category %@ to '%@'!", category, path);
+            return NO;
+        }
+        GBLogDebug(@"Finished generating output for category %@.", category);
+    }
+    return YES;
+}
+
+- (BOOL)processProtocols:(NSError **)error {
+    for (GBProtocolData *protocol in self.store.protocols) {
+        if (!protocol.includeInOutput) continue;
+        GBLogInfo(@"Generating output for protocol %@...", protocol);
+        NSDictionary *vars = [self.variablesProvider variablesForProtocol:protocol withStore:self.store];
+        NSString *output = [self.markdownTemplate renderObject:vars];
+//        NSString *output = [self.htmlObjectTemplate renderObject:vars];
+        NSString *cleaned = [self stringByCleaningHtml:output];
+        NSString *path = [self htmlOutputPathForObject:protocol];
+        if (![self writeString:cleaned toFile:[path stringByStandardizingPath] error:error]) {
+            GBLogWarn(@"Failed writing HTML for protocol %@ to '%@'!", protocol, path);
+            return NO;
+        }
+        GBLogDebug(@"Finished generating output for protocol %@.", protocol);
+    }
+    return YES;
+}
+
+- (BOOL)processConstants:(NSError **)error {
+    for (GBTypedefEnumData *enumTypedef in self.store.constants) {
+        if (!enumTypedef.includeInOutput) continue;
+        GBLogInfo(@"Generating output for constant %@...", enumTypedef);
+        NSDictionary *vars = [self.variablesProvider variablesForConstant:enumTypedef withStore:self.store];
+        NSString *output = [self.markdownTemplate renderObject:vars];
+//        NSString *output = [self.htmlObjectTemplate renderObject:vars];
+        NSString *cleaned = [self stringByCleaningHtml:output];
+        NSString *path = [self htmlOutputPathForObject:enumTypedef];
+        if (![self writeString:cleaned toFile:[path stringByStandardizingPath] error:error]) {
+            GBLogWarn(@"Failed writing HTML for constant %@ to '%@'!", enumTypedef, path);
+            return NO;
+        }
+        GBLogDebug(@"Finished generating output for constant %@.", enumTypedef);
+    }
+    return YES;
+}
+
+- (BOOL)processBlocks:(NSError **)error {
+    for (GBTypedefBlockData *blockTypedef in self.store.blocks) {
+        if (!blockTypedef.includeInOutput) continue;
+        GBLogInfo(@"Generating output for block %@...", blockTypedef);
+        NSDictionary *vars = [self.variablesProvider variablesForBlocks:blockTypedef withStore:self.store];
+        NSString *output = [self.markdownTemplate renderObject:vars];
+//        NSString *output = [self.htmlObjectTemplate renderObject:vars];
+        NSString *cleaned = [self stringByCleaningHtml:output];
+        NSString *path = [self htmlOutputPathForObject:blockTypedef];
+        if (![self writeString:cleaned toFile:[path stringByStandardizingPath] error:error]) {
+            GBLogWarn(@"Failed writing HTML for block %@ to '%@'!", blockTypedef, path);
+            return NO;
+        }
+        GBLogDebug(@"Finished generating output for block %@.", blockTypedef);
+    }
+    return YES;
+}
+
+
+- (BOOL)validateTemplates:(NSError **)error {
+    if (!self.markdownTemplate) {
+        if (error) {
+            NSString *desc = [NSString stringWithFormat:@"Markdown template file 'markdown-template.md' is missing at '%@'!", self.templateUserPath];
+            *error = [NSError errorWithCode:4000 description:desc reason:nil];
+        }
+        return NO;
+    }
+    return YES;
+}
+
+#pragma mark Helper methods
+
+- (NSString *)stringByCleaningHtml:(NSString *)string {
+    // Nothing to do at this point - as we're preserving all whitespace, we should be just fine with generated string. The method is still left as a placeholder for possible future handling.
+    return string;
+}
+
+- (NSString *)htmlOutputPathForObject:(GBModelBase *)object {
+    // Returns file name including full path for HTML file representing the given top-level object. This works for any top-level object: class, category or protocol. The path is automatically determined regarding to the object class. Note that we use the HTML reference to get us the actual path - we can't rely on template filename as it's the same for all objects...
+    NSString *inner = [self.settings htmlReferenceForObjectFromIndex:object];
+    return [self.outputUserPath stringByAppendingPathComponent:inner];
+}
+
+//- (NSString *)htmlOutputPathForTemplateName:(NSString *)template {
+//    // Returns full path and actual file name corresponding to the given template.
+//    NSString *path = [self outputPathToTemplateEndingWith:template];
+//    NSString *filename = [self.settings outputFilenameForTemplatePath:template];
+//    return [path stringByAppendingPathComponent:filename];
+//}
+
+- (GBHTMLTemplateVariablesProvider *)variablesProvider {
+    static GBHTMLTemplateVariablesProvider *result = nil;
+    if (!result) {
+        GBLogDebug(@"Initializing variables provider...");
+        result = [[GBHTMLTemplateVariablesProvider alloc] initWithSettingsProvider:self.settings];
+    }
+    return result;
+}
+
+- (GBTemplateHandler *)markdownTemplate {
+    return self.templateFiles[@"markdown-template.html"];
+}
+
+//- (GBTemplateHandler *)htmlObjectTemplate {
+//    return self.templateFiles[@"object-template.html"];
+//}
+
+
+#pragma mark Overriden methods
+
+- (NSString *)outputSubpath {
+    return @"markdown";
+}
+
+
+@end

--- a/Generating/GBMarkdownOutputGenerator.m
+++ b/Generating/GBMarkdownOutputGenerator.m
@@ -158,20 +158,6 @@
     return [self.outputUserPath stringByAppendingPathComponent:inner];
 }
 
-//- (NSString *)htmlOutputPathForObject:(GBModelBase *)object {
-//    // Returns file name including full path for m file representing the given top-level object. This works for any top-level object: class, category or protocol. The path is automatically determined regarding to the object class. Note that we use the HTML reference to get us the actual path - we can't rely on template filename as it's the same for all objects...
-//    NSString *inner = [self.settings htmlReferenceForObjectFromIndex:object];
-//    //NSString *inner = [self.settings outputPathForObject:object withExtension:@"md"];
-//    return [self.outputUserPath stringByAppendingPathComponent:inner];
-//}
-
-//- (NSString *)htmlOutputPathForTemplateName:(NSString *)template {
-//    // Returns full path and actual file name corresponding to the given template.
-//    NSString *path = [self outputPathToTemplateEndingWith:template];
-//    NSString *filename = [self.settings outputFilenameForTemplatePath:template];
-//    return [path stringByAppendingPathComponent:filename];
-//}
-
 
 - (GBHTMLTemplateVariablesProvider *)variablesProvider {
     static GBHTMLTemplateVariablesProvider *result = nil;
@@ -185,10 +171,6 @@
 - (GBTemplateHandler *)markdownTemplate {
     return self.templateFiles[@"markdown-template.md"];
 }
-
-//- (GBTemplateHandler *)htmlObjectTemplate {
-//    return self.templateFiles[@"object-template.html"];
-//}
 
 
 #pragma mark Overriden methods

--- a/Generating/GBMarkdownOutputGenerator.m
+++ b/Generating/GBMarkdownOutputGenerator.m
@@ -145,10 +145,14 @@
 - (NSString *)stringByCleaningHtml:(NSString *)string {
     // Remove excess whitespace
     NSError *err;
-    NSRegularExpression *removeNewLinesRegx = [NSRegularExpression regularExpressionWithPattern:@"[\\n]{2,}" options:0 error:&err];
-    NSRegularExpression *removePTagRegx = [NSRegularExpression regularExpressionWithPattern:@"<p>|</p>" options:0 error:&err];
-    string = [removeNewLinesRegx stringByReplacingMatchesInString:string options:0 range:NSMakeRange(0, string.length) withTemplate:@"\n\n"];
-    string = [removePTagRegx stringByReplacingMatchesInString:string options:0 range:NSMakeRange(0, string.length) withTemplate:@""];
+    NSRegularExpression *newLinesMatchRegx = [NSRegularExpression regularExpressionWithPattern:@"[\\n]{2,}" options:0 error:&err];
+    NSRegularExpression *paragraphMatchRegx = [NSRegularExpression regularExpressionWithPattern:@"<p>|</p>" options:0 error:&err];
+    NSRegularExpression *divMatchRegx = [NSRegularExpression regularExpressionWithPattern:@"<div(.*?)>" options:0 error:&err];
+    NSRegularExpression *divCloseMatchRegx = [NSRegularExpression regularExpressionWithPattern:@"<\\/div>" options:0 error:&err];
+    string = [newLinesMatchRegx stringByReplacingMatchesInString:string options:0 range:NSMakeRange(0, string.length) withTemplate:@"\n\n"];
+    string = [paragraphMatchRegx stringByReplacingMatchesInString:string options:0 range:NSMakeRange(0, string.length) withTemplate:@""];
+    string = [divMatchRegx stringByReplacingMatchesInString:string options:0 range:NSMakeRange(0, string.length) withTemplate:@"\n\n"];
+    string = [divCloseMatchRegx stringByReplacingMatchesInString:string options:0 range:NSMakeRange(0, string.length) withTemplate:@""];
     return string;
 }
 

--- a/Templates/markdown/markdown-template.md
+++ b/Templates/markdown/markdown-template.md
@@ -1,0 +1,275 @@
+
+# {{page.title}}
+
+{{#page.specifications}}
+{{#used}}{{/used}}
+	{{#values}}{{>ObjectSpecification}}{{/values}}
+	{{#used}}{{/used}}
+{{/page.specifications}}
+
+{{#object.comment}}
+{{#hasLongDescription}}
+## {{strings.objectOverview.title}}
+
+{{#longDescription}}{{>GBCommentComponentsList}}{{/longDescription}}
+{{/hasLongDescription}}
+{{/object.comment}}
+
+{{#object.methods}}
+{{#hasSections}}
+## {{strings.objectTasks.title}}
+
+{{#sections}}
+{{#sectionName}}{{/sectionName}}
+{{>TaskTitle}}
+{{#methods}}
+{{>TaskMethod}}
+{{/methods}}
+{{/sections}}
+{{/hasSections}}
+{{/object.methods}}
+
+{{#object.methods}}
+{{#hasProperties}}
+## {{strings.objectMethods.propertiesTitle}}
+
+{{#properties}}
+{{>Method}}
+{{/properties}}
+{{/hasProperties}}
+
+{{#hasClassMethods}}
+<a title="{{strings.objectMethods.classMethodsTitle}}" name="class_methods"></a>
+## {{strings.objectMethods.classMethodsTitle}}
+{{#classMethods}}
+{{>Method}}
+{{/classMethods}}
+{{/hasClassMethods}}
+
+{{#hasInstanceMethods}}
+<a title="{{strings.objectMethods.instanceMethodsTitle}}" name="instance_methods"></a>
+## {{strings.objectMethods.instanceMethodsTitle}}
+
+{{#instanceMethods}}
+{{>Method}}
+{{/instanceMethods}}
+{{/hasInstanceMethods}}
+{{/object.methods}}
+
+{{#typedefEnum}}
+### {{nameOfEnum}}
+{{#comment}}
+{{#hasLongDescription}}
+{{#longDescription}}{{>GBCommentComponentsList}}{{/longDescription}}
+{{/hasLongDescription}}
+{{/comment}}
+
+
+{{#constants}}
+#### Definition
+    typedef {{enumStyle}}({{enumPrimitive}}, {{nameOfEnum}} ) {   
+        {{#constants}}
+        <a href="{{htmlLocalReference}}">{{name}}</a>{{#hasAssignedValue}} = {{assignedValue}}{{/hasAssignedValue}},  
+        {{/constants}}
+    };
+{{/constants}}
+
+{{#constants}}
+#### Constants
+{{#constants}}
+{{>Constant}}
+{{/constants}}
+{{/constants}}
+
+{{#comment}}
+{{#hasAvailability}}
+#### {{strings.objectMethods.availability}}
+{{#availability}}{{>GBCommentComponentsList}}{{/availability}}
+{{/hasAvailability}}
+
+{{#hasRelatedItems}}
+#### {{strings.objectMethods.seeAlsoTitle}}
+{{#relatedItems.components}}
+* `{{>GBCommentComponent}}`
+{{/relatedItems.components}}
+{{/hasRelatedItems}}
+
+{{#prefferedSourceInfo}}
+#### {{strings.objectMethods.declaredInTitle}}
+`{{filename}}`
+{{/prefferedSourceInfo}}
+{{/comment}}
+{{/typedefEnum}}
+
+{{#typedefBlock}}
+<a title="{{strings.objectMethods.blockDefTitle}}" name="instance_methods"></a>
+## {{strings.objectMethods.blockDefTitle}}
+{{>BlocksDefList}}
+{{/typedefBlock}}
+
+
+
+Section Method
+<a name="{{htmlReferenceName}}" title="{{methodSelector}}"></a>
+### {{methodSelector}}
+{{#comment}}
+{{#hasShortDescription}}
+{{#shortDescription}}{{>GBCommentComponent}}{{/shortDescription}}
+{{/hasShortDescription}}
+{{/comment}}
+`{{>MethodDeclaration}}`
+{{#comment}}
+
+{{#hasMethodParameters}}
+#### {{strings.objectMethods.parametersTitle}}
+{{#methodParameters}}
+*{{argumentName}}*  
+&nbsp;&nbsp;&nbsp;{{#argumentDescription}}{{>GBCommentComponentsList}}{{/argumentDescription}}  
+{{/methodParameters}}
+{{/hasMethodParameters}}
+
+{{#hasMethodResult}}
+#### {{strings.objectMethods.resultTitle}}
+{{#methodResult}}{{>GBCommentComponentsList}}{{/methodResult}}
+{{/hasMethodResult}}
+
+{{#hasAvailability}}
+#### {{strings.objectMethods.availability}}
+{{#availability}}{{>GBCommentComponentsList}}{{/availability}}
+{{/hasAvailability}}
+
+{{#hasLongDescription}}
+#### {{strings.objectMethods.discussionTitle}}
+{{#longDescription}}{{>GBCommentComponentsList}}{{/longDescription}}
+{{/hasLongDescription}}
+
+{{#hasMethodExceptions}}
+#### {{strings.objectMethods.exceptionsTitle}}
+{{#methodExceptions}}
+*{{argumentName}}*  
+&nbsp;&nbsp;&nbsp;{{#argumentDescription}}{{>GBCommentComponentsList}}{{/argumentDescription}}  
+{{/methodExceptions}}
+{{/hasMethodExceptions}}
+
+{{#hasRelatedItems}}
+#### {{strings.objectMethods.seeAlsoTitle}}
+{{#relatedItems.components}}
+* `{{>GBCommentComponent}}`
+{{/relatedItems.components}}
+{{/hasRelatedItems}}
+
+{{#prefferedSourceInfo}}
+#### {{strings.objectMethods.declaredInTitle}}
+* `{{filename}}`
+{{/prefferedSourceInfo}}
+{{/comment}}
+EndSection
+
+Section MethodDeclaration
+{{#formattedComponents}}{{#emphasized}}<em>{{/emphasized}}{{#href}}<a href="{{&href}}">{{/href}}{{value}}{{#href}}</a>{{/href}}{{#emphasized}}</em>{{/emphasized}}{{/formattedComponents}}
+EndSection
+
+
+Section TaskTitle
+{{#hasMultipleSections}}
+### {{#sectionName}}{{.}}{{/sectionName}}{{^sectionName}}{{strings.objectTasks.otherMethodsSectionName}}{{/sectionName}}
+{{/hasMultipleSections}}
+{{^hasMultipleSections}}
+### {{#sectionName}}{{.}}{{/sectionName}}
+{{/hasMultipleSections}}
+EndSection
+
+Section TaskMethod
+[{{>TaskSelector}}]({{htmlLocalReference}})
+*{{#isProperty}}{{strings.objectTasks.property}}{{/isProperty}}*  
+*{{#isRequired}}{{strings.objectTasks.requiredMethod}}{{/isRequired}}*  
+EndSection
+
+Section TaskSelector
+{{#isInstanceMethod}}&ndash;&nbsp;{{/isInstanceMethod}}{{#isClassMethod}}+&nbsp;{{/isClassMethod}}{{#isProperty}}&nbsp;&nbsp;{{/isProperty}}{{methodSelector}}
+EndSection
+
+
+Section GBCommentComponentsList
+{{#components}}{{>GBCommentComponent}}{{/components}}
+EndSection
+
+Section BlocksDefList
+### {{nameOfBlock}}
+{{#comment}}
+{{#hasShortDescription}}
+{{#shortDescription}}{{>GBCommentComponent}}{{/shortDescription}}
+{{/hasShortDescription}}
+{{/comment}}
+
+<code>typedef {{returnType}} (^{{nameOfBlock}}) ({{&htmlParameterList}})</code>
+
+{{#comment}}
+{{#hasLongDescription}}
+####{{strings.objectMethods.discussionTitle}}
+{{#longDescription}}{{>GBCommentComponentsList}}{{/longDescription}}
+{{/hasLongDescription}}
+{{/comment}}
+
+{{#comment}}
+{{#hasAvailability}}
+#### {{strings.objectMethods.availability}}
+{{#availability}}{{>GBCommentComponentsList}}{{/availability}}
+{{/hasAvailability}}
+
+{{#hasRelatedItems}}
+#### {{strings.objectMethods.seeAlsoTitle}}
+{{#relatedItems.components}}
+* <code>{{>GBCommentComponent}}</code>
+{{/relatedItems.components}}
+{{/hasRelatedItems}}
+
+{{#prefferedSourceInfo}}
+#### {{strings.objectMethods.declaredInTitle}}
+<code class="declared-in-ref">{{filename}}</code>
+{{/prefferedSourceInfo}}
+{{/comment}}
+EndSection
+
+Section Constant
+<a name="{{htmlReferenceName}}" title="{{name}}"></a><code>{{name}}</code>
+{{#comment}}
+{{#hasShortDescription}}
+{{#shortDescription}}{{>GBCommentComponent}}{{/shortDescription}}
+{{/hasShortDescription}}
+
+{{#hasAvailability}}
+Available in {{#availability}}{{#components}}{{stringValue}}{{/components}}{{/availability}}
+{{/hasAvailability}}
+
+{{/comment}}
+{{#prefferedSourceInfo}}
+&nbsp;&nbsp;&nbsp;{{strings.objectMethods.declaredInTitle}} <code class="declared-in-ref">{{filename}}</code>.
+{{/prefferedSourceInfo}}
+EndSection
+
+Section Block
+<a name="{{htmlReferenceName}}" title="{{name}}"></a><code>{{name}}</code>
+{{#comment}}
+{{#hasShortDescription}}
+{{#shortDescription}}{{>GBCommentComponent}}{{/shortDescription}}
+{{/hasShortDescription}}
+
+{{#hasAvailability}}
+&nbsp;&nbsp;&nbsp;Available in {{#availability}}{{#components}}{{stringValue}}{{/components}}{{/availability}}</p>
+{{/hasAvailability}}
+
+{{/comment}}
+{{#prefferedSourceInfo}}
+&nbsp;&nbsp;&nbsp;{{strings.objectMethods.declaredInTitle}} <code class="declared-in-ref">{{filename}}</code>.
+{{/prefferedSourceInfo}}
+EndSection
+
+
+Section GBCommentComponent
+{{&htmlValue}}
+EndSection
+
+Section ObjectSpecification
+**{{title}}** {{#values}}
+EndSection

--- a/Templates/markdown/markdown-template.md
+++ b/Templates/markdown/markdown-template.md
@@ -1,26 +1,21 @@
 
 # {{page.title}}
-
 {{#page.specifications}}
-{{#used}}{{/used}}
-	{{#values}}{{>ObjectSpecification}}{{/values}}
-	{{#used}}{{/used}}
+{{#values}}{{>ObjectSpecification}}{{/values}}
 {{/page.specifications}}
 
-{{#object.comment}}
-{{#hasLongDescription}}
+{{#object.comment}}{{#hasLongDescription}}
 ## {{strings.objectOverview.title}}
-
-{{#longDescription}}{{>GBCommentComponentsList}}{{/longDescription}}
+{{#longDescription}}
+{{>GBCommentComponentsList}}
+{{/longDescription}}
 {{/hasLongDescription}}
 {{/object.comment}}
 
 {{#object.methods}}
 {{#hasSections}}
 ## {{strings.objectTasks.title}}
-
 {{#sections}}
-{{#sectionName}}{{/sectionName}}
 {{>TaskTitle}}
 {{#methods}}
 {{>TaskMethod}}
@@ -32,12 +27,10 @@
 {{#object.methods}}
 {{#hasProperties}}
 ## {{strings.objectMethods.propertiesTitle}}
-
 {{#properties}}
 {{>Method}}
 {{/properties}}
 {{/hasProperties}}
-
 {{#hasClassMethods}}
 <a title="{{strings.objectMethods.classMethodsTitle}}" name="class_methods"></a>
 ## {{strings.objectMethods.classMethodsTitle}}
@@ -45,11 +38,9 @@
 {{>Method}}
 {{/classMethods}}
 {{/hasClassMethods}}
-
 {{#hasInstanceMethods}}
 <a title="{{strings.objectMethods.instanceMethodsTitle}}" name="instance_methods"></a>
 ## {{strings.objectMethods.instanceMethodsTitle}}
-
 {{#instanceMethods}}
 {{>Method}}
 {{/instanceMethods}}
@@ -63,8 +54,6 @@
 {{#longDescription}}{{>GBCommentComponentsList}}{{/longDescription}}
 {{/hasLongDescription}}
 {{/comment}}
-
-
 {{#constants}}
 #### Definition
     typedef {{enumStyle}}({{enumPrimitive}}, {{nameOfEnum}} ) {   
@@ -73,27 +62,23 @@
         {{/constants}}
     };
 {{/constants}}
-
 {{#constants}}
 #### Constants
 {{#constants}}
 {{>Constant}}
 {{/constants}}
 {{/constants}}
-
 {{#comment}}
 {{#hasAvailability}}
 #### {{strings.objectMethods.availability}}
 {{#availability}}{{>GBCommentComponentsList}}{{/availability}}
 {{/hasAvailability}}
-
 {{#hasRelatedItems}}
 #### {{strings.objectMethods.seeAlsoTitle}}
 {{#relatedItems.components}}
 * `{{>GBCommentComponent}}`
 {{/relatedItems.components}}
 {{/hasRelatedItems}}
-
 {{#prefferedSourceInfo}}
 #### {{strings.objectMethods.declaredInTitle}}
 `{{filename}}`
@@ -109,6 +94,43 @@
 
 
 
+
+
+
+
+Section ObjectSpecification
+&nbsp;&nbsp;**{{title}}** {{#values}}{{#href}}<a href="{{&href}}">{{/href}}{{string}}{{#href}}</a>{{/href}}{{&delimiter}}  
+{{/values}}
+EndSection
+
+Section GBCommentComponentsList
+{{#components}}{{>GBCommentComponent}}{{/components}}
+EndSection
+
+Section GBCommentComponent
+{{&htmlValue}}
+EndSection
+
+Section TaskTitle
+{{#hasMultipleSections}}
+###  {{#sectionName}}{{.}}{{/sectionName}}{{^sectionName}}{{strings.objectTasks.otherMethodsSectionName}}{{/sectionName}}
+{{/hasMultipleSections}}
+{{^hasMultipleSections}}
+### {{#sectionName}}{{.}}{{/sectionName}}
+{{/hasMultipleSections}}
+EndSection
+
+Section TaskMethod
+[{{>TaskSelector}}]({{htmlLocalReference}})
+{{#isProperty}}*{{strings.objectTasks.property}}*{{/isProperty}}  
+{{#isRequired}}*{{strings.objectTasks.requiredMethod}}*{{/isRequired}}  
+EndSection
+
+Section TaskSelector
+{{#isInstanceMethod}}&ndash;&nbsp;{{/isInstanceMethod}}{{#isClassMethod}}+&nbsp;{{/isClassMethod}}{{#isProperty}}&nbsp;&nbsp;{{/isProperty}}{{methodSelector}}
+EndSection
+
+
 Section Method
 <a name="{{htmlReferenceName}}" title="{{methodSelector}}"></a>
 ### {{methodSelector}}
@@ -119,7 +141,6 @@ Section Method
 {{/comment}}
 `{{>MethodDeclaration}}`
 {{#comment}}
-
 {{#hasMethodParameters}}
 #### {{strings.objectMethods.parametersTitle}}
 {{#methodParameters}}
@@ -127,22 +148,18 @@ Section Method
 &nbsp;&nbsp;&nbsp;{{#argumentDescription}}{{>GBCommentComponentsList}}{{/argumentDescription}}  
 {{/methodParameters}}
 {{/hasMethodParameters}}
-
 {{#hasMethodResult}}
 #### {{strings.objectMethods.resultTitle}}
 {{#methodResult}}{{>GBCommentComponentsList}}{{/methodResult}}
 {{/hasMethodResult}}
-
 {{#hasAvailability}}
 #### {{strings.objectMethods.availability}}
 {{#availability}}{{>GBCommentComponentsList}}{{/availability}}
 {{/hasAvailability}}
-
 {{#hasLongDescription}}
 #### {{strings.objectMethods.discussionTitle}}
 {{#longDescription}}{{>GBCommentComponentsList}}{{/longDescription}}
 {{/hasLongDescription}}
-
 {{#hasMethodExceptions}}
 #### {{strings.objectMethods.exceptionsTitle}}
 {{#methodExceptions}}
@@ -150,14 +167,12 @@ Section Method
 &nbsp;&nbsp;&nbsp;{{#argumentDescription}}{{>GBCommentComponentsList}}{{/argumentDescription}}  
 {{/methodExceptions}}
 {{/hasMethodExceptions}}
-
 {{#hasRelatedItems}}
 #### {{strings.objectMethods.seeAlsoTitle}}
 {{#relatedItems.components}}
 * `{{>GBCommentComponent}}`
 {{/relatedItems.components}}
 {{/hasRelatedItems}}
-
 {{#prefferedSourceInfo}}
 #### {{strings.objectMethods.declaredInTitle}}
 * `{{filename}}`
@@ -166,33 +181,27 @@ Section Method
 EndSection
 
 Section MethodDeclaration
-{{#formattedComponents}}{{#emphasized}}<em>{{/emphasized}}{{#href}}<a href="{{&href}}">{{/href}}{{value}}{{#href}}</a>{{/href}}{{#emphasized}}</em>{{/emphasized}}{{/formattedComponents}}
+{{#formattedComponents}}{{#emphasized}}*{{/emphasized}}{{#href}}<a href="{{&href}}">{{/href}}{{value}}{{#href}}</a>{{/href}}{{#emphasized}}*{{/emphasized}}{{/formattedComponents}}
 EndSection
 
 
-Section TaskTitle
-{{#hasMultipleSections}}
-### {{#sectionName}}{{.}}{{/sectionName}}{{^sectionName}}{{strings.objectTasks.otherMethodsSectionName}}{{/sectionName}}
-{{/hasMultipleSections}}
-{{^hasMultipleSections}}
-### {{#sectionName}}{{.}}{{/sectionName}}
-{{/hasMultipleSections}}
-EndSection
-
-Section TaskMethod
-[{{>TaskSelector}}]({{htmlLocalReference}})
-*{{#isProperty}}{{strings.objectTasks.property}}{{/isProperty}}*  
-*{{#isRequired}}{{strings.objectTasks.requiredMethod}}{{/isRequired}}*  
-EndSection
-
-Section TaskSelector
-{{#isInstanceMethod}}&ndash;&nbsp;{{/isInstanceMethod}}{{#isClassMethod}}+&nbsp;{{/isClassMethod}}{{#isProperty}}&nbsp;&nbsp;{{/isProperty}}{{methodSelector}}
+Section Constant
+<a name="{{htmlReferenceName}}" title="{{name}}"></a><code>{{name}}</code>
+{{#comment}}
+{{#hasShortDescription}}
+{{#shortDescription}}{{>GBCommentComponent}}{{/shortDescription}}
+{{/hasShortDescription}}
+{{#hasAvailability}}
+Available in {{#availability}}{{#components}}{{stringValue}}{{/components}}{{/availability}}
+{{/hasAvailability}}
+{{/comment}}
+{{#prefferedSourceInfo}}
+&nbsp;&nbsp;&nbsp;{{strings.objectMethods.declaredInTitle}} `{{filename}}`.
+{{/prefferedSourceInfo}}
 EndSection
 
 
-Section GBCommentComponentsList
-{{#components}}{{>GBCommentComponent}}{{/components}}
-EndSection
+
 
 Section BlocksDefList
 ### {{nameOfBlock}}
@@ -201,75 +210,27 @@ Section BlocksDefList
 {{#shortDescription}}{{>GBCommentComponent}}{{/shortDescription}}
 {{/hasShortDescription}}
 {{/comment}}
-
 <code>typedef {{returnType}} (^{{nameOfBlock}}) ({{&htmlParameterList}})</code>
-
 {{#comment}}
 {{#hasLongDescription}}
-####{{strings.objectMethods.discussionTitle}}
+#### {{strings.objectMethods.discussionTitle}}
 {{#longDescription}}{{>GBCommentComponentsList}}{{/longDescription}}
 {{/hasLongDescription}}
 {{/comment}}
-
 {{#comment}}
 {{#hasAvailability}}
 #### {{strings.objectMethods.availability}}
 {{#availability}}{{>GBCommentComponentsList}}{{/availability}}
 {{/hasAvailability}}
-
 {{#hasRelatedItems}}
 #### {{strings.objectMethods.seeAlsoTitle}}
 {{#relatedItems.components}}
 * <code>{{>GBCommentComponent}}</code>
 {{/relatedItems.components}}
 {{/hasRelatedItems}}
-
 {{#prefferedSourceInfo}}
 #### {{strings.objectMethods.declaredInTitle}}
 <code class="declared-in-ref">{{filename}}</code>
 {{/prefferedSourceInfo}}
 {{/comment}}
-EndSection
-
-Section Constant
-<a name="{{htmlReferenceName}}" title="{{name}}"></a><code>{{name}}</code>
-{{#comment}}
-{{#hasShortDescription}}
-{{#shortDescription}}{{>GBCommentComponent}}{{/shortDescription}}
-{{/hasShortDescription}}
-
-{{#hasAvailability}}
-Available in {{#availability}}{{#components}}{{stringValue}}{{/components}}{{/availability}}
-{{/hasAvailability}}
-
-{{/comment}}
-{{#prefferedSourceInfo}}
-&nbsp;&nbsp;&nbsp;{{strings.objectMethods.declaredInTitle}} <code class="declared-in-ref">{{filename}}</code>.
-{{/prefferedSourceInfo}}
-EndSection
-
-Section Block
-<a name="{{htmlReferenceName}}" title="{{name}}"></a><code>{{name}}</code>
-{{#comment}}
-{{#hasShortDescription}}
-{{#shortDescription}}{{>GBCommentComponent}}{{/shortDescription}}
-{{/hasShortDescription}}
-
-{{#hasAvailability}}
-&nbsp;&nbsp;&nbsp;Available in {{#availability}}{{#components}}{{stringValue}}{{/components}}{{/availability}}</p>
-{{/hasAvailability}}
-
-{{/comment}}
-{{#prefferedSourceInfo}}
-&nbsp;&nbsp;&nbsp;{{strings.objectMethods.declaredInTitle}} <code class="declared-in-ref">{{filename}}</code>.
-{{/prefferedSourceInfo}}
-EndSection
-
-
-Section GBCommentComponent
-{{&htmlValue}}
-EndSection
-
-Section ObjectSpecification
-**{{title}}** {{#values}}
 EndSection

--- a/Templates/markdown/markdown-template.md
+++ b/Templates/markdown/markdown-template.md
@@ -58,7 +58,7 @@
 #### Definition
     typedef {{enumStyle}}({{enumPrimitive}}, {{nameOfEnum}} ) {   
         {{#constants}}
-        <a href="{{htmlLocalReference}}">{{name}}</a>{{#hasAssignedValue}} = {{assignedValue}}{{/hasAssignedValue}},  
+        {{name}}{{#hasAssignedValue}} = {{assignedValue}}{{/hasAssignedValue}},
         {{/constants}}
     };
 {{/constants}}
@@ -113,7 +113,7 @@ EndSection
 
 Section TaskTitle
 {{#hasMultipleSections}}
-###  {{#sectionName}}{{.}}{{/sectionName}}{{^sectionName}}{{strings.objectTasks.otherMethodsSectionName}}{{/sectionName}}
+### {{#sectionName}}{{.}}{{/sectionName}}{{^sectionName}}{{strings.objectTasks.otherMethodsSectionName}}{{/sectionName}}
 {{/hasMultipleSections}}
 {{^hasMultipleSections}}
 ### {{#sectionName}}{{.}}{{/sectionName}}
@@ -121,9 +121,7 @@ Section TaskTitle
 EndSection
 
 Section TaskMethod
-[{{>TaskSelector}}]({{htmlLocalReference}})
-{{#isProperty}}*{{strings.objectTasks.property}}*{{/isProperty}}  
-{{#isRequired}}*{{strings.objectTasks.requiredMethod}}*{{/isRequired}}  
+[{{>TaskSelector}}]({{htmlLocalReference}}) {{#isProperty}}*{{strings.objectTasks.property}}*{{/isProperty}} {{#isRequired}}*{{strings.objectTasks.requiredMethod}}*{{/isRequired}}  
 EndSection
 
 Section TaskSelector

--- a/appledoc.xcodeproj/project.pbxproj
+++ b/appledoc.xcodeproj/project.pbxproj
@@ -182,7 +182,7 @@
 		D4B844EC17A121040012C1DC /* GBTypedefEnumData.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B844EB17A121030012C1DC /* GBTypedefEnumData.m */; };
 		D4B844EF17A122670012C1DC /* GBEnumConstantData.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B844EE17A122650012C1DC /* GBEnumConstantData.m */; };
 		D4B844F217A122A60012C1DC /* GBEnumConstantProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B844F117A122A50012C1DC /* GBEnumConstantProvider.m */; };
-		D818BAD015203AA700B26451 /* OCHamcrest.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 73FC6E1E11FCD5E200AAD0B9 /* OCHamcrest.framework */; };
+		D818BAD015203AA700B26451 /* OCHamcrest.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 73FC6E1E11FCD5E200AAD0B9 /* OCHamcrest.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		DA77C691196BEB2C0018A48F /* dd_getopt_long-fbsd.m in Sources */ = {isa = PBXBuildFile; fileRef = DA77C690196BEB2C0018A48F /* dd_getopt_long-fbsd.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DA98B5911972151100059171 /* GBTypedefBlockData.m in Sources */ = {isa = PBXBuildFile; fileRef = C56768101958403800E8E4C8 /* GBTypedefBlockData.m */; };
 		DA98B5921972151100059171 /* GBTypedefBlockArgument.m in Sources */ = {isa = PBXBuildFile; fileRef = C5676813195840BD00E8E4C8 /* GBTypedefBlockArgument.m */; };
@@ -947,7 +947,7 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0600;
+				LastUpgradeCheck = 0920;
 				ORGANIZATIONNAME = "Gentle Bytes";
 			};
 			buildConfigurationList = 1DEB927808733DD40010E9CD /* Build configuration list for PBXProject "appledoc" */;
@@ -1365,6 +1365,7 @@
 		1DEB927908733DD40010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -1381,6 +1382,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -1409,6 +1411,7 @@
 		1DEB927A08733DD40010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -1482,6 +1485,7 @@
 					AppKit,
 					"$(inherited)",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.gentlebytes.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = AppledocTests;
 				TEST_HOST = "$(BUNDLE_LOADER)";
 			};
@@ -1520,6 +1524,7 @@
 					AppKit,
 					"$(inherited)",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.gentlebytes.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = AppledocTests;
 			};
 			name = Release;

--- a/appledoc.xcodeproj/project.pbxproj
+++ b/appledoc.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		31DBC2AE18060C3C002AFE9F /* GBDocSetFinalizeGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 31DBC2AD18060C3C002AFE9F /* GBDocSetFinalizeGenerator.m */; };
 		31DBC2AF18060EFF002AFE9F /* GBDocSetFinalizeGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 31DBC2AD18060C3C002AFE9F /* GBDocSetFinalizeGenerator.m */; };
+		425CC22E20488BEA0099B364 /* GBHTMLOutputGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 425CC22D20488BEA0099B364 /* GBHTMLOutputGenerator.m */; };
+		425CC23120488D630099B364 /* GBMarkdownOutputGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 425CC23020488D630099B364 /* GBMarkdownOutputGenerator.m */; };
 		4CFB67FB906500574239C6AE /* libPods-appledoc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 493739BF5A98CB9200764326 /* libPods-appledoc.a */; };
 		7307B311124A1929007EC6B8 /* GBObjectiveCParser-SectionsParsingTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = 7307B310124A1929007EC6B8 /* GBObjectiveCParser-SectionsParsingTesting.m */; };
 		7307B31A124A1C2E007EC6B8 /* GBMethodSectionData.m in Sources */ = {isa = PBXBuildFile; fileRef = 7307B319124A1C2E007EC6B8 /* GBMethodSectionData.m */; };
@@ -20,7 +22,6 @@
 		7317CC1012B113BF009DAA15 /* GBGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 73AA9F721253BF4000074152 /* GBGenerator.m */; };
 		7317CC1112B113CC009DAA15 /* DDCliParseException.m in Sources */ = {isa = PBXBuildFile; fileRef = 73D54D1811F8D53E00CCDDB0 /* DDCliParseException.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		7317CC1212B113CF009DAA15 /* DDGetoptLongParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 73D54D1D11F8D53E00CCDDB0 /* DDGetoptLongParser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		7317CC1312B113E4009DAA15 /* GBHTMLOutputGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 73473D3012A38B730011336C /* GBHTMLOutputGenerator.m */; };
 		7317CC1412B113EB009DAA15 /* GBOutputGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 73D2524512A2ED610024F9F9 /* GBOutputGenerator.m */; };
 		7317CC1512B113ED009DAA15 /* GBDocSetOutputGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 731872C412A3B75C0035509F /* GBDocSetOutputGenerator.m */; };
 		7317CC1612B113F8009DAA15 /* GBTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 73397A2712A5070700EDC035 /* GBTask.m */; };
@@ -90,7 +91,6 @@
 		733EA194122BE1A30060CBDE /* DDCliUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 73D54D1A11F8D53E00CCDDB0 /* DDCliUtil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		7340F02811FCC63100E712A4 /* NSFileManager+GBFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7340F02511FCC63100E712A4 /* NSFileManager+GBFileManager.m */; };
 		7340F02911FCC63100E712A4 /* NSObject+GBObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 7340F02711FCC63100E712A4 /* NSObject+GBObject.m */; };
-		73473D3112A38B730011336C /* GBHTMLOutputGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 73473D3012A38B730011336C /* GBHTMLOutputGenerator.m */; };
 		735259D713793ED7003F0D09 /* GBExitCodes.m in Sources */ = {isa = PBXBuildFile; fileRef = 73C4C8601377DFF70024FA77 /* GBExitCodes.m */; };
 		735B23811304024600704844 /* GBDocumentData.m in Sources */ = {isa = PBXBuildFile; fileRef = 735B23801304024600704844 /* GBDocumentData.m */; };
 		735B23821304083C00704844 /* GBDocumentData.m in Sources */ = {isa = PBXBuildFile; fileRef = 735B23801304024600704844 /* GBDocumentData.m */; };
@@ -110,7 +110,6 @@
 		7382CA82130479F7006C5966 /* GBTemplateFilesHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 735B2386130418A000704844 /* GBTemplateFilesHandler.m */; };
 		739AD57F1255C3E600B642C3 /* GBApplicationStringsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 739AD57E1255C3E600B642C3 /* GBApplicationStringsProvider.m */; };
 		739AD5801255C3E600B642C3 /* GBApplicationStringsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 739AD57E1255C3E600B642C3 /* GBApplicationStringsProvider.m */; };
-		739AD62F1255D8CB00B642C3 /* GBHTMLTemplateVariablesProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 739AD62E1255D8CB00B642C3 /* GBHTMLTemplateVariablesProvider.m */; };
 		739AD6301255D8CB00B642C3 /* GBHTMLTemplateVariablesProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 739AD62E1255D8CB00B642C3 /* GBHTMLTemplateVariablesProvider.m */; };
 		739AD6521255E32A00B642C3 /* GBTemplateVariablesProvider-CommonTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = 739AD6511255E32A00B642C3 /* GBTemplateVariablesProvider-CommonTesting.m */; };
 		739C0C4712AC258B00F0130B /* GBProcessor-UndocumentedObjectsTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = 739C0C4612AC258B00F0130B /* GBProcessor-UndocumentedObjectsTesting.m */; };
@@ -212,6 +211,10 @@
 		31DBC2AC18060C3C002AFE9F /* GBDocSetFinalizeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GBDocSetFinalizeGenerator.h; sourceTree = "<group>"; };
 		31DBC2AD18060C3C002AFE9F /* GBDocSetFinalizeGenerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GBDocSetFinalizeGenerator.m; sourceTree = "<group>"; };
 		381DEFAF9452E40F08F040D5 /* Pods-AppledocTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppledocTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AppledocTests/Pods-AppledocTests.release.xcconfig"; sourceTree = "<group>"; };
+		425CC22C20488BEA0099B364 /* GBHTMLOutputGenerator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GBHTMLOutputGenerator.h; sourceTree = "<group>"; };
+		425CC22D20488BEA0099B364 /* GBHTMLOutputGenerator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GBHTMLOutputGenerator.m; sourceTree = "<group>"; };
+		425CC22F20488D630099B364 /* GBMarkdownOutputGenerator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GBMarkdownOutputGenerator.h; sourceTree = "<group>"; };
+		425CC23020488D630099B364 /* GBMarkdownOutputGenerator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GBMarkdownOutputGenerator.m; sourceTree = "<group>"; };
 		493739BF5A98CB9200764326 /* libPods-appledoc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-appledoc.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C75E5BD2E1BFF5CD130FE5A /* Pods-appledoc.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-appledoc.debug.xcconfig"; path = "Pods/Target Support Files/Pods-appledoc/Pods-appledoc.debug.xcconfig"; sourceTree = "<group>"; };
 		720DA055AE3DBDBE5E8FF024 /* libPods-AppledocTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AppledocTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -246,8 +249,6 @@
 		7340F02511FCC63100E712A4 /* NSFileManager+GBFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+GBFileManager.m"; sourceTree = "<group>"; };
 		7340F02611FCC63100E712A4 /* NSObject+GBObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+GBObject.h"; sourceTree = "<group>"; };
 		7340F02711FCC63100E712A4 /* NSObject+GBObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+GBObject.m"; sourceTree = "<group>"; };
-		73473D2F12A38B730011336C /* GBHTMLOutputGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GBHTMLOutputGenerator.h; sourceTree = "<group>"; };
-		73473D3012A38B730011336C /* GBHTMLOutputGenerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GBHTMLOutputGenerator.m; sourceTree = "<group>"; };
 		735B237F1304024600704844 /* GBDocumentData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GBDocumentData.h; sourceTree = "<group>"; };
 		735B23801304024600704844 /* GBDocumentData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GBDocumentData.m; sourceTree = "<group>"; };
 		735B238313040CEB00704844 /* GBDocumentDataTesting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GBDocumentDataTesting.m; sourceTree = "<group>"; };
@@ -568,10 +569,12 @@
 				73AA9F721253BF4000074152 /* GBGenerator.m */,
 				73D2524412A2ED610024F9F9 /* GBOutputGenerator.h */,
 				73D2524512A2ED610024F9F9 /* GBOutputGenerator.m */,
-				73473D2F12A38B730011336C /* GBHTMLOutputGenerator.h */,
-				73473D3012A38B730011336C /* GBHTMLOutputGenerator.m */,
+				425CC22C20488BEA0099B364 /* GBHTMLOutputGenerator.h */,
+				425CC22D20488BEA0099B364 /* GBHTMLOutputGenerator.m */,
 				739AD62D1255D8CB00B642C3 /* GBHTMLTemplateVariablesProvider.h */,
 				739AD62E1255D8CB00B642C3 /* GBHTMLTemplateVariablesProvider.m */,
+				425CC22F20488D630099B364 /* GBMarkdownOutputGenerator.h */,
+				425CC23020488D630099B364 /* GBMarkdownOutputGenerator.m */,
 				731872C312A3B75C0035509F /* GBDocSetOutputGenerator.h */,
 				731872C412A3B75C0035509F /* GBDocSetOutputGenerator.m */,
 				31DBC2AC18060C3C002AFE9F /* GBDocSetFinalizeGenerator.h */,
@@ -1137,7 +1140,6 @@
 				733EA14D122BDECD0060CBDE /* GBObjectiveCParser-IvarsParsingTesting.m in Sources */,
 				733EA14E122BDECE0060CBDE /* GBObjectiveCParser-MethodsParsingTesting.m in Sources */,
 				7317CC1512B113ED009DAA15 /* GBDocSetOutputGenerator.m in Sources */,
-				7317CC1312B113E4009DAA15 /* GBHTMLOutputGenerator.m in Sources */,
 				7317CC1712B11424009DAA15 /* NSError+GBError.m in Sources */,
 				733EA14F122BDECE0060CBDE /* GBObjectiveCParser-ProtocolParsingTesting.m in Sources */,
 				733EA150122BDECF0060CBDE /* GBObjectsAssertor.m in Sources */,
@@ -1181,7 +1183,6 @@
 				7307B31A124A1C2E007EC6B8 /* GBMethodSectionData.m in Sources */,
 				736B2BF6124BCBB6009145B1 /* GBSourceInfo.m in Sources */,
 				739AD57F1255C3E600B642C3 /* GBApplicationStringsProvider.m in Sources */,
-				739AD62F1255D8CB00B642C3 /* GBHTMLTemplateVariablesProvider.m in Sources */,
 				739AD6521255E32A00B642C3 /* GBTemplateVariablesProvider-CommonTesting.m in Sources */,
 				736A2751125841420078F4FE /* GBTemplateVariablesProvider-ObjectSpecificationsTesting.m in Sources */,
 				736A275F125845000078F4FE /* GBApplicationSettingsProvider.m in Sources */,
@@ -1255,6 +1256,7 @@
 				73F2CA76123E4161009B406B /* GBCommentsProcessor.m in Sources */,
 				73F2CA77123E4161009B406B /* GBProcessor.m in Sources */,
 				7307B31B124A1C2E007EC6B8 /* GBMethodSectionData.m in Sources */,
+				425CC23120488D630099B364 /* GBMarkdownOutputGenerator.m in Sources */,
 				736B2BF7124BCBB6009145B1 /* GBSourceInfo.m in Sources */,
 				DA98B5921972151100059171 /* GBTypedefBlockArgument.m in Sources */,
 				73AA9F731253BF4000074152 /* GBGenerator.m in Sources */,
@@ -1270,11 +1272,11 @@
 				73F568C312A22A7900A72BB2 /* DDLog.m in Sources */,
 				73F568C512A22A7900A72BB2 /* DDTTYLogger.m in Sources */,
 				73D2524612A2ED610024F9F9 /* GBOutputGenerator.m in Sources */,
-				73473D3112A38B730011336C /* GBHTMLOutputGenerator.m in Sources */,
 				731872C512A3B75C0035509F /* GBDocSetOutputGenerator.m in Sources */,
 				73397A2812A5070700EDC035 /* GBTask.m in Sources */,
 				732E6CBD12DF02B7009DD6E0 /* NSArray+GBArray.m in Sources */,
 				7335F72B12E58DCC0094F72E /* GBDocSetInstallGenerator.m in Sources */,
+				425CC22E20488BEA0099B364 /* GBHTMLOutputGenerator.m in Sources */,
 				7335F72E12E58E160094F72E /* GBDocSetPublishGenerator.m in Sources */,
 				735B23811304024600704844 /* GBDocumentData.m in Sources */,
 				735B2387130418A100704844 /* GBTemplateFilesHandler.m in Sources */,

--- a/appledoc.xcodeproj/xcshareddata/xcschemes/AppledocTests.xcscheme
+++ b/appledoc.xcodeproj/xcshareddata/xcschemes/AppledocTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -45,6 +46,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/appledoc.xcodeproj/xcshareddata/xcschemes/appledoc.xcscheme
+++ b/appledoc.xcodeproj/xcshareddata/xcschemes/appledoc.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -45,6 +46,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/appledoc.xcodeproj/xcshareddata/xcschemes/appledoc.xcscheme
+++ b/appledoc.xcodeproj/xcshareddata/xcschemes/appledoc.xcscheme
@@ -63,12 +63,6 @@
             ReferencedContainer = "container:appledoc.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "--project-name &quot;NativoSDK&quot; --project-company &quot;Nativo&quot; --company-id com.nativo --templates  &quot;/Users/mmurray/Documents/appledoc/Templates/&quot; --output &quot;/Users/mmurray/Documents/appledoc/Nativo Docs/&quot; --logformat 1 --verbose 5 --exit-threshold 2 --ignore .m --explicit-crossref --no-warn-undocumented-object  --no-warn-undocumented-member --no-create-html --create-markdown --no-warn-empty-description  &quot;/Users/mmurray/Documents/Nativo/NativoSDK-iOS/NativoSDK-iOS-Workspace/NativoSDK-iOS/NativoSDK/Public&quot;"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/appledoc.xcodeproj/xcshareddata/xcschemes/appledoc.xcscheme
+++ b/appledoc.xcodeproj/xcshareddata/xcschemes/appledoc.xcscheme
@@ -63,6 +63,12 @@
             ReferencedContainer = "container:appledoc.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--project-name &quot;NativoSDK&quot; --project-company &quot;Nativo&quot; --company-id com.nativo --templates  &quot;/Users/mmurray/Documents/appledoc/Templates/&quot; --output &quot;/Users/mmurray/Documents/appledoc/Nativo Docs/&quot; --logformat 1 --verbose 5 --exit-threshold 2 --ignore .m --explicit-crossref --no-warn-undocumented-object  --no-warn-undocumented-member --no-create-html --create-markdown --no-warn-empty-description  &quot;/Users/mmurray/Documents/Nativo/NativoSDK-iOS/NativoSDK-iOS-Workspace/NativoSDK-iOS/NativoSDK/Public&quot;"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
Created a new generator that outputs reference docs in markdown instead of html. Simply add `--create-markdown` to the parameters when running. Useful for uploading markdown reference docs to sites like Readme.io or Github. Note: Linking and cross-referencing may not work as originally intended.